### PR TITLE
Cleanup spec loader

### DIFF
--- a/src/relation_engine_server/spec_loader.py
+++ b/src/relation_engine_server/spec_loader.py
@@ -6,71 +6,88 @@ import os
 import json
 import subprocess  # nosec
 
-_spec_path = os.environ.get('SPEC_PATH', '/spec')
+_spec_dir = os.environ.get('SPEC_PATH', '/spec')
+_view_dir = os.path.join(_spec_dir, 'views')
+_schema_dir = os.path.join(_spec_dir, 'schemas')
+_vertex_dir = os.path.join(_schema_dir, 'vertices')
+_edge_dir = os.path.join(_schema_dir, 'edges')
 
 
 def get_schema_names():
-    """Return a list of all schema names."""
+    """Return a dict of vertex and edge base names."""
     git_pull()
-    schema_path = os.path.join(_spec_path, 'schemas')
-    return _get_file_names(schema_path, '.json')
+    return {
+        'vertices': [
+            _get_file_name(path)
+            for path in _find_paths(_vertex_dir, '*.json')
+        ],
+        'edges': [
+            _get_file_name(path)
+            for path in _find_paths(_edge_dir, '*.json')
+        ]
+    }
 
 
 def get_view_names():
-    """Return a list of all view names."""
+    """Return an array of all view base names."""
     git_pull()
-    view_path = os.path.join(_spec_path, 'views')
-    return _get_file_names(view_path, '.aql')
+    return [
+        _get_file_name(path)
+        for path in _find_paths(_view_dir, '*.aql')
+    ]
 
 
-def get_view_content(names):
-    """Return the AQL source code for a view."""
-    views = {}
-    view_names = get_view_names()
-    for name in names:
-        if name not in view_names:
-            raise ViewNonexistent(name, view_names)
-        view_path = os.path.join(_spec_path, 'views', name + '.aql')
-        with open(view_path, 'r') as fd:
-            views[name] = fd.read()
-    return views
+def get_schema(name):
+    """Get JSON content for a specific schema. Throws an error if nonexistent."""
+    git_pull()
+    try:
+        path = _find_paths(_schema_dir, name + '.json')[0]
+    except IndexError:
+        raise SchemaNonexistent(name)
+    with open(path, 'r', encoding='utf8') as fd:
+        return json.load(fd)
 
 
-def get_schema_dicts(names):
-    """Return a particular JSON schema as a python dict."""
-    schemas = {}
-    schema_names = get_schema_names()
-    for name in names:
-        if name not in schema_names:
-            raise SchemaNonexistent(name, schema_names)
-        schema_path = glob.glob(os.path.join(_spec_path, 'schemas', '**', name + '.json'),
-                                recursive=True)[0]
-        with open(schema_path, 'r') as fd:
-            schemas[name] = json.loads(fd.read())
-    return schemas
+def get_view(name):
+    """Get AQL content for a specific view. Throws an error if nonexistent."""
+    git_pull()
+    try:
+        path = _find_paths(_view_dir, name + '.aql')[0]
+    except IndexError:
+        raise ViewNonexistent(name)
+    with open(path, 'r', encoding='utf8') as fd:
+        return fd.read()
 
 
 def git_pull():
     """Git pull the spec repo to get any updates."""
-    output = subprocess.check_output(['git', '-C', _spec_path, 'rev-list', 'HEAD..origin/master', '--count'])  # nosec
-    change_count = int(output.strip())
-    if change_count > 0:
-        output = subprocess.check_output(['git', '-C', _spec_path, 'pull'])  # nosec
-        print('git pull output', output)
-    return output
+    output = subprocess.check_output(['git', '-C', _spec_dir, 'fetch'])  # nosec
+    if output:
+        # Pull if there were updates on fetch
+        subprocess.check_output(['git', '-C', _spec_dir, 'pull'])  # nosec
 
 
-def _get_file_names(dir_path, target_extension):
-    """Get a list of file basenames in all subdirectory of a dir_path with a certain extension."""
-    return [os.path.basename(p) for p in glob.iglob(os.path.join(dir_path, '**', '*' + target_extension), recursive=True)]
+def _find_paths(dir_path, file_pattern):
+    """
+    Return all file paths from a filename pattern, starting from a parent
+    directory and looking in all subdirectories.
+    """
+    pattern = os.path.join(dir_path, '**', file_pattern)
+    return glob.glob(pattern, recursive=True)
+
+
+def _get_file_name(path):
+    """
+    Get the file base name without extension from a file path.
+    """
+    return os.path.splitext(os.path.basename(path))[0]
 
 
 class ViewNonexistent(Exception):
     """Requested view is not in the spec."""
 
-    def __init__(self, name, available):
+    def __init__(self, name):
         self.name = name
-        self.available = available
 
     def __str__(self):
         return 'View does not exist.'
@@ -79,9 +96,8 @@ class ViewNonexistent(Exception):
 class SchemaNonexistent(Exception):
     """Requested schema is not in the spec."""
 
-    def __init__(self, name, available):
+    def __init__(self, name):
         self.name = name
-        self.available = available
 
     def __str__(self):
         return 'Schema does not exist.'

--- a/src/test/test_api.py
+++ b/src/test/test_api.py
@@ -8,7 +8,7 @@ import requests
 import json
 import os
 
-url = 'http://web:5000'
+url = os.environ.get('TEST_URL', 'http://web:5000')
 auth_token = os.environ.get('KBASE_TEST_AUTH_TOKEN', '')
 headers = {'Authorization': 'Bearer ' + auth_token}
 example_data = '\n'.join([


### PR DESCRIPTION
The spec_loader module was getting a little hairy, so I did some clean up. I also updated the API around fetching view and schema names and content. 

GET /api/views -> array of names
GET /api/schemas -> object of 'edges' and 'vertices', each an array of names
GET /api/views/<name> -> Get aql for a single view as text/plain
GET /api/schemas/<name> -> Get JSON for a single schema