### PR TITLE
Initialize collections when pulling new schemas

### DIFF
--- a/src/relation_engine_server/arango_client.py
+++ b/src/relation_engine_server/arango_client.py
@@ -68,26 +68,25 @@ def init_collections(schemas):
 
 
 def create_collection(name, is_edge):
+    """
+    Create a single collection by name using some basic defaults.
+    We ignore duplicates. For any other server error, an exception is thrown.
+    """
     url = db_url + '/_api/collection'
     # collection types:
     #   2 is a document collection
     #   3 is an edge collection
     collection_type = 3 if is_edge else 2
-    resp = requests.post(
-        url,
-        data=json.dumps({
-            'keyOptions': {
-                'allowUserKeys': True,
-            },
-            'name': name,
-            'type': collection_type
-        }),
-        auth=(db_user, db_pass)
-    ).json()
+    data = json.dumps({
+        'keyOptions': {'allowUserKeys': True},
+        'name': name,
+        'type': collection_type
+    })
+    resp = requests.post(url, data, auth=(db_user, db_pass))
     if resp['error']:
         if 'duplicate' not in resp['errorMessage']:
             # Unable to create a collection
-            raise Exception(resp.text)
+            raise ArangoServerError(resp.text)
 
 
 def bulk_import(file_path, query):

--- a/src/relation_engine_server/spec_loader.py
+++ b/src/relation_engine_server/spec_loader.py
@@ -6,6 +6,8 @@ import os
 import json
 import subprocess  # nosec
 
+from . import arango_client
+
 _spec_dir = os.environ.get('SPEC_PATH', '/spec')
 _view_dir = os.path.join(_spec_dir, 'views')
 _schema_dir = os.path.join(_spec_dir, 'schemas')
@@ -61,6 +63,8 @@ def git_pull():
     if output:
         # Pull if there were updates on fetch
         subprocess.check_output(['git', '-C', _spec_dir, 'pull'])  # nosec
+        # Initialize any collections
+        arango_client.init_collections(get_schema_names())
     return bool(output)
 
 


### PR DESCRIPTION
Automatically create new collections on a schema update with some basic defaults.

This does not handle renames or removals. For that, we might rather use migrations.

Closes issue #3 