### PR TITLE
Add a error details display option for imports with a test case

### DIFF
--- a/src/relation_engine_server/api.py
+++ b/src/relation_engine_server/api.py
@@ -85,6 +85,9 @@ def save_documents():
     auth.require_auth_token(['RE_ADMIN'])
     collection_name = flask.request.args['collection']
     query = {'collection': collection_name, 'type': 'documents'}
+    if flask.request.args.get('display_errors'):
+        # Display an array of error messages
+        query['details'] = 'true'
     schema = spec_loader.get_schema(collection_name)
     if flask.request.args.get('on_duplicate'):
         query['onDuplicate'] = flask.request.args['on_duplicate']

--- a/src/test/test_api.py
+++ b/src/test/test_api.py
@@ -137,14 +137,16 @@ class TestApi(unittest.TestCase):
 
     def test_save_documents_dupe_errors(self):
         """Test where we want to raise errors on duplicate documents."""
+        save_test_docs(3)
         resp = requests.put(
             url + '/api/documents',
-            params={'on_duplicate': 'error', 'collection': 'example_vertices'},
+            params={'on_duplicate': 'error', 'collection': 'example_vertices', 'display_errors': '1'},
             data=create_test_docs(3),
             headers=headers
         ).json()
-        expected = {'created': 0, 'errors': 3, 'empty': 0, 'updated': 0, 'ignored': 0, 'error': False}
-        self.assertEqual(resp, expected)
+        self.assertEqual(resp['created'], 0)
+        self.assertEqual(resp['errors'], 3)
+        self.assertTrue(resp['details'])
 
     def test_save_documents_ignore_dupes(self):
         """Test ignoring duplicate, existing documents when saving."""


### PR DESCRIPTION
In PUT /api/documents, you can use the query parameter "display_errors" to get error messages (useful for debugging). Set the param to something truthy to enable it. 