### PR TITLE
Make spec pulls more robust

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ _Example response_
 Fetch the registered schema names.
 
 _Example request_
-
 ```sh
 $ curl -X GET http://relation_engine/api/schemas
 ```
@@ -84,7 +83,7 @@ _Example response_
 }
 ```
 
-### POST /query_results
+### POST /api/query_results
 
 Run a query using a view or a cursor ID. Semantically, this is a GET, but it's a POST to allow better support for passing JSON in the request body (eg. Postman doesn't allow request body data in get requests)
 
@@ -153,7 +152,7 @@ _Response JSON schema_
 
 Results are limited to 100 items. To continue fetching additional results, use the `cursor_id` below:
 
-### PUT /documents
+### PUT /api/documents
 
 Bulk-update documents by either creating, replacing, or updating.
 
@@ -215,6 +214,20 @@ _Response JSON schema_
   }
 }
 ```
+
+### GET /api/update_specs
+
+Manually check and pull spec updates. Requires sysadmin auth.
+
+_Example_
+
+```
+$ curl http://relation_engine/api/update_specs
+```
+
+_Query params_
+* `init_collections` - optional - boolean - whether to initialize any new collections in arango
+* `reset` - optional - boolean - whether to completely reset the spec data (do a clean download and overwrite)
 
 ## Python client API
 

--- a/src/relation_engine_server/api.py
+++ b/src/relation_engine_server/api.py
@@ -65,13 +65,17 @@ def show_view(name):
     return flask.Response(spec_loader.get_view(name), mimetype='text/plain')
 
 
-@api.route('/refresh_specs', methods=['GET'])
+@api.route('/update_specs', methods=['GET'])
 def refresh_specs():
     """
     Manually pull from the spec git repo to get updates.
     """
-    git_output = pull_spec.pull_spec()
-    return flask.jsonify({"updates": git_output})
+    auth.require_auth_token(['RE_ADMIN'])
+    status = pull_spec.download_latest(
+        reset='reset' in flask.request.args,
+        init_collections='init_collections' in flask.request.args
+    )
+    return flask.jsonify({'status': status})
 
 
 @api.route('/documents', methods=['PUT'])

--- a/src/relation_engine_server/api.py
+++ b/src/relation_engine_server/api.py
@@ -68,7 +68,7 @@ def show_view(name):
 @api.route('/update_specs', methods=['GET'])
 def refresh_specs():
     """
-    Manually pull from the spec git repo to get updates.
+    Manually check for updates, download spec releases, and init new collections.
     """
     auth.require_auth_token(['RE_ADMIN'])
     status = pull_spec.download_latest(

--- a/src/relation_engine_server/pull_spec.py
+++ b/src/relation_engine_server/pull_spec.py
@@ -1,21 +1,91 @@
 import os
-import subprocess  # nosec
+import requests
+import tarfile
+import tempfile
+import shutil
 
 from . import arango_client, spec_loader
 
 _spec_dir = os.environ.get('SPEC_PATH', '/spec')
+_api_url = 'https://api.github.com/repos/kbase/relation_engine_spec'
+_release_id_path = os.path.join(_spec_dir, '.release_id')
 
 
-def pull_spec():
-    """Download the spec repo to get any updates."""
-    # This always git-pulls no matter what. We may want to throttle or change this in the future.
-    subprocess.check_output(['git', '-C', _spec_dir, 'pull', 'origin', 'master'])  # nosec
-    # Initialize any collections
-    arango_client.init_collections(spec_loader.get_schema_names())
+def download_latest(reset=False, init_collections=True):
+    """Check and download the latest spec and extract it to the spec path."""
+    if reset and os.path.exists(_spec_dir):
+        shutil.rmtree(_spec_dir)
+    os.makedirs(_spec_dir, exist_ok=True)
+    # Download information about the latest release
+    release_resp = requests.get(_api_url + '/releases/latest')
+    release_info = release_resp.json()
+    if release_resp.status_code != 200:
+        # This may be a github API rate usage limit, or some other error
+        return release_info['message']
+    if _has_latest_spec(release_info):
+        return 'already up to date: ' + release_info['tag_name']
+    # Download and extract a new release to /spec/repo
+    spec_repo_path = os.path.join(_spec_dir, 'repo')
+    tarball_url = release_info['tarball_url']
+    resp = requests.get(tarball_url, stream=True)
+    temp_file = tempfile.NamedTemporaryFile()
+    # Download from the tarball url to the temp file
+    _download_file(resp, temp_file.name)
+    # Extract the downloaded tarball into the spec path
+    _extract_tarball(temp_file.name, _spec_dir)
+    temp_file.close()  # Also deletes it
+    # The files will be extracted into a directory like /spec/kbase-relation_engine_spec-xyz
+    # We want to move that to /spec/repo
+    _rename_directories(_spec_dir, spec_repo_path)
+    # Save the release ID to /spec/.release_id
+    _save_release_id(release_info)
+    # Initialize all the collections
+    if init_collections:
+        schemas = spec_loader.get_schema_names()
+        arango_client.init_collections(schemas)
+    return 'updated to ' + release_info['tag_name']
 
 
-# Run from bash with `python -m src.relation_engine_server.pull_spec`
-if __name__ == '__main__':
-    print('Pulling relation engine spec..')
-    pull_spec()
-    print('..done.')
+def _download_file(resp, path):
+    """Download a streaming response as a file to path."""
+    with open(path, 'wb') as tar_file:
+        for chunk in resp.iter_content(chunk_size=1024):
+            tar_file.write(chunk)
+
+
+def _extract_tarball(tar_path, dest_dir):
+    """Extract a gzipped tarball to a destination directory."""
+    with tarfile.open(tar_path, 'r:gz') as tar:
+        tar.extractall(path=dest_dir)
+
+
+def _rename_directories(dir_path, dest_path):
+    """
+    Rename directories under a path.
+    The files will be extracted into a directory like /spec/kbase-relation_engine_spec-xyz
+    We want to move it to /spec/repo.
+    This could probably be improved to be less confusing.
+    """
+    for file_name in os.listdir(dir_path):
+        file_path = os.path.join(dir_path, file_name)
+        if os.path.isdir(file_path):
+            os.rename(file_path, dest_path)
+
+
+def _has_latest_spec(info):
+    """Check if downloaded release info matches the latest downloaded spec."""
+    release_id = str(info['id'])
+    if os.path.exists(_release_id_path):
+        with open(_release_id_path, 'r') as fd:
+            current_release_id = fd.read()
+        if release_id == current_release_id:
+            return True
+    return False
+
+
+def _save_release_id(info):
+    """Save a release ID as the latest downloaded spec."""
+    release_id = str(info['id'])
+    # Write the release ID to /spec/.release_id
+    with open(_release_id_path, 'w') as fd:
+        fd.write(release_id)

--- a/src/relation_engine_server/pull_spec.py
+++ b/src/relation_engine_server/pull_spec.py
@@ -28,12 +28,12 @@ def download_latest(reset=False, init_collections=True):
     spec_repo_path = os.path.join(_spec_dir, 'repo')
     tarball_url = release_info['tarball_url']
     resp = requests.get(tarball_url, stream=True)
-    temp_file = tempfile.NamedTemporaryFile()
-    # Download from the tarball url to the temp file
-    _download_file(resp, temp_file.name)
-    # Extract the downloaded tarball into the spec path
-    _extract_tarball(temp_file.name, _spec_dir)
-    temp_file.close()  # Also deletes it
+    with tempfile.NamedTemporaryFile() as temp_file:
+        # The temp file will be closed/deleted when the context ends
+        # Download from the tarball url to the temp file
+        _download_file(resp, temp_file.name)
+        # Extract the downloaded tarball into the spec path
+        _extract_tarball(temp_file.name, _spec_dir)
     # The files will be extracted into a directory like /spec/kbase-relation_engine_spec-xyz
     # We want to move that to /spec/repo
     _rename_directories(_spec_dir, spec_repo_path)

--- a/src/relation_engine_server/spec_loader.py
+++ b/src/relation_engine_server/spec_loader.py
@@ -5,11 +5,12 @@ import glob
 import os
 import json
 
-_spec_dir = os.environ.get('SPEC_PATH', '/spec')
-_view_dir = os.path.join(_spec_dir, 'views')
-_schema_dir = os.path.join(_spec_dir, 'schemas')
-_vertex_dir = os.path.join(_schema_dir, 'vertices')
-_edge_dir = os.path.join(_schema_dir, 'edges')
+_spec_root_dir = os.environ.get('SPEC_PATH', '/spec')
+_spec_dir = os.path.join(_spec_root_dir, 'repo')  # /spec/repo
+_view_dir = os.path.join(_spec_dir, 'views')  # /spec/repo/views
+_schema_dir = os.path.join(_spec_dir, 'schemas')  # /spec/repo/schemas
+_vertex_dir = os.path.join(_schema_dir, 'vertices')  # /spec/repo/schemas/vertices
+_edge_dir = os.path.join(_schema_dir, 'edges')  # /spec/repo/schemas/edges
 
 
 def get_schema_names():

--- a/src/test/test_api.py
+++ b/src/test/test_api.py
@@ -51,6 +51,13 @@ class TestApi(unittest.TestCase):
         self.assertTrue(resp['commit_hash'])
         self.assertTrue(resp['repo_url'])
 
+    def test_update_specs(self):
+        resp = requests.get(
+            url + '/api/update_specs',
+            headers={'Authorization': 'Bearer ' + auth_token}
+        ).json()
+        self.assertTrue(len(resp['status']))
+
     def test_list_views(self):
         resp = requests.get(url + '/api/views').json()
         self.assertTrue('list_all_documents_in_collection' in resp)

--- a/src/test/test_api.py
+++ b/src/test/test_api.py
@@ -55,8 +55,10 @@ class TestApi(unittest.TestCase):
         resp = requests.get(
             url + '/api/update_specs',
             headers={'Authorization': 'Bearer ' + auth_token}
-        ).json()
-        self.assertTrue(len(resp['status']))
+        )
+        resp_json = resp.json()
+        self.assertEqual(resp.status_code, 200)
+        self.assertTrue(len(resp_json['status']))
 
     def test_list_views(self):
         resp = requests.get(url + '/api/views').json()

--- a/src/test/test_api.py
+++ b/src/test/test_api.py
@@ -54,7 +54,8 @@ class TestApi(unittest.TestCase):
     def test_update_specs(self):
         resp = requests.get(
             url + '/api/update_specs',
-            headers={'Authorization': 'Bearer ' + auth_token}
+            headers={'Authorization': 'Bearer ' + auth_token},
+            params={'reset': '1', 'init_collections': '1'}
         )
         resp_json = resp.json()
         self.assertEqual(resp.status_code, 200)


### PR DESCRIPTION
Use gzipped github releases and the github API to pull spec updates.

Added a sanity check test case and some minimal docs

Related issue https://github.com/kbase/relation_engine_api/issues/10