### PR TITLE
Enable cross-origin requests

### DIFF
--- a/src/relation_engine_server/server.py
+++ b/src/relation_engine_server/server.py
@@ -77,4 +77,12 @@ def server_error(err):
 def log_response(response):
     """Simple log of each request's response."""
     print(' '.join([flask.request.method, flask.request.path, '->', response.status]))
+    # Enable CORS
+    # Content type and length
+    response.headers['Access-Control-Allow-Origin'] = '*'
+    env_allowed_headers = os.environ.get('HTTP_ACCESS_CONTROL_REQUEST_HEADERS', 'authorization')
+    response.headers['Access-Control-Allow-Headers'] = env_allowed_headers
+    # Set JSON content type and responseonse length
+    response.headers['Content-Type'] = 'application/json'
+    response.headers['Content-Length'] = response.calculate_content_length()
     return response

--- a/src/relation_engine_server/server.py
+++ b/src/relation_engine_server/server.py
@@ -82,7 +82,7 @@ def after_request(response):
     response.headers['Access-Control-Allow-Origin'] = '*'
     env_allowed_headers = os.environ.get('HTTP_ACCESS_CONTROL_REQUEST_HEADERS', 'authorization')
     response.headers['Access-Control-Allow-Headers'] = env_allowed_headers
-    # Set JSON content type and responseonse length
+    # Set JSON content type and response length
     response.headers['Content-Type'] = 'application/json'
     response.headers['Content-Length'] = response.calculate_content_length()
     return response

--- a/src/relation_engine_server/server.py
+++ b/src/relation_engine_server/server.py
@@ -74,7 +74,7 @@ def server_error(err):
 
 
 @app.after_request
-def log_response(response):
+def after_request(response):
     """Simple log of each request's response."""
     print(' '.join([flask.request.method, flask.request.path, '->', response.status]))
     # Enable CORS


### PR DESCRIPTION
Allows cross origin web client requests and also adds a couple standard response headers.