### PR TITLE
Add json endpoint for viewing non-private config data

### DIFF
--- a/src/relation_engine_server/server.py
+++ b/src/relation_engine_server/server.py
@@ -7,7 +7,7 @@ import traceback
 from jsonschema.exceptions import ValidationError
 
 from .exceptions import MissingHeader, UnauthorizedAccess
-from .utils import arango_client, spec_loader, auth, bulk_import, pull_spec
+from .utils import arango_client, spec_loader, auth, bulk_import, pull_spec, config
 
 app = flask.Flask(__name__)
 app.config['DEBUG'] = os.environ.get('FLASK_DEBUG', True)
@@ -29,6 +29,19 @@ def root():
         'arangodb_status': arangodb_status,
         'commit_hash': commit_hash,
         'repo_url': repo_url
+    })
+
+
+@app.route('/config', methods=['GET'])
+def show_config():
+    conf = config.get_config()
+    return flask.jsonify({
+        'auth_url': conf['auth_url'],
+        'workspace_url': conf['workspace_url'],
+        'kbase_endpoint': conf['kbase_endpoint'],
+        'db_url': conf['db_url'],
+        'db_name': conf['db_name'],
+        'spec_url': conf['spec_url']
     })
 
 

--- a/src/test/test_api.py
+++ b/src/test/test_api.py
@@ -68,6 +68,16 @@ class TestApi(unittest.TestCase):
         self.assertTrue(resp['commit_hash'])
         self.assertTrue(resp['repo_url'])
 
+    def test_config(self):
+        """Test config fetch."""
+        resp = requests.get(URL + '/config').json()
+        self.assertTrue(len(resp['auth_url']))
+        self.assertTrue(len(resp['workspace_url']))
+        self.assertTrue(len(resp['kbase_endpoint']))
+        self.assertTrue(len(resp['db_url']))
+        self.assertTrue(len(resp['db_name']))
+        self.assertTrue(len(resp['spec_url']))
+
     def test_update_specs(self):
         """Test the endpoint that triggers an update on the specs."""
         resp = requests.get(


### PR DESCRIPTION
This is something I'm finding very useful in the sketch service. This allows us to see all non-private config by doing a get request to "/config"