### PR TITLE
Allow users to pass a batch_size parameter with queries

### DIFF
--- a/src/relation_engine_server/utils/arango_client.py
+++ b/src/relation_engine_server/utils/arango_client.py
@@ -22,12 +22,12 @@ def server_status():
         return 'unknown_failure'
 
 
-def run_query(query_text=None, cursor_id=None, bind_vars={}):
+def run_query(query_text=None, cursor_id=None, bind_vars=None, batch_size=100):
     """Run a query using the arangodb http api. Can return a cursor to get more results."""
     config = get_config()
     url = config['db_url'] + '/_api/cursor'
     req_json = {
-        'batchSize': 100,
+        'batchSize': min(5000, batch_size),
         'memoryLimit': 16000000000  # 16gb
     }
     if cursor_id:
@@ -36,8 +36,9 @@ def run_query(query_text=None, cursor_id=None, bind_vars={}):
     else:
         method = 'POST'
         req_json['count'] = True
-        req_json['bindVars'] = bind_vars
         req_json['query'] = query_text
+        if bind_vars:
+            req_json['bindVars'] = bind_vars
 
     resp = requests.request(
         method,

--- a/src/test/test_api.py
+++ b/src/test/test_api.py
@@ -278,25 +278,25 @@ class TestApi(unittest.TestCase):
         self.assertEqual(resp['error'], '403 - Unauthorized')
 
     def test_query_with_cursor(self):
-        """Test getting more data via a query cursor."""
-        save_test_docs(count=200)
+        """Test getting more data via a query cursor and setting batch size."""
+        save_test_docs(count=20)
         resp = requests.post(
             URL + '/api/query_results',
-            params={'view': 'list_test_vertices'}
+            params={'view': 'list_test_vertices', 'batch_size': 10}
         ).json()
-        cursor_id = resp['cursor_id']
         self.assertTrue(resp['cursor_id'])
         self.assertEqual(resp['has_more'], True)
-        self.assertEqual(resp['count'], 200)
-        self.assertTrue(len(resp['results']), 100)
+        self.assertEqual(resp['count'], 20)
+        self.assertTrue(len(resp['results']), 10)
+        cursor_id = resp['cursor_id']
         resp = requests.post(
             URL + '/api/query_results',
             params={'cursor_id': cursor_id}
         ).json()
-        self.assertEqual(resp['count'], 200)
+        self.assertEqual(resp['count'], 20)
         self.assertEqual(resp['has_more'], False)
         self.assertEqual(resp['cursor_id'], None)
-        self.assertTrue(len(resp['results']), 100)
+        self.assertTrue(len(resp['results']), 10)
         # Try to get the same cursor again
         resp = requests.post(
             URL + '/api/query_results',


### PR DESCRIPTION
Currently maxes out at 5000 and defaults to 100.