### PR TITLE
Tweak the script to only have the --reload flag if DEVELOPMENT=1

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -15,6 +15,9 @@ services:
     volumes:
       - ${PWD}:/app
     environment:
+      - DEVELOPMENT=1
+      - FLASK_ENV=development
+      - FLASK_DEBUG=1
       - KBASE_AUTH_URL=http://auth:5000
       - KBASE_WORKSPACE_URL=http://workspace:5000
       - PYTHONUNBUFFERED=true
@@ -22,8 +25,6 @@ services:
       - DB_URL=http://arangodb:8529
       - DB_USER=root
       - DB_PASS=password
-      - FLASK_ENV=development
-      - FLASK_DEBUG=1
 
   # For running (and testing against) ArangoDB
   arangodb:

--- a/scripts/start_server.sh
+++ b/scripts/start_server.sh
@@ -1,5 +1,4 @@
 #!/bin/sh
-
 set -e
 
 # Set the number of gevent workers to number of cores * 2 + 1
@@ -8,4 +7,10 @@ calc_workers="$(($(nproc) * 2 + 1))"
 # Use the WORKERS environment variable, if present
 workers=${WORKERS:-$calc_workers}
 
-gunicorn --worker-class gevent --timeout 1800 --workers $workers -b :5000 --reload src.relation_engine_server.server:app
+gunicorn \
+  --worker-class gevent \
+  --timeout 1800 \
+  --workers $workers \
+  --bind :5000 \
+  ${DEVELOPMENT:+"--reload"} \
+  src.relation_engine_server.server:app


### PR DESCRIPTION
I think the file-watching that happens with the --reload flag is causing unneeded load when the server is idle, according to mr. shane