### PR TITLE
Add release_url param to the download_specs function

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,8 +237,10 @@ $ curl http://relation_engine/api/update_specs
 ```
 
 _Query params_
-* `init_collections` - optional - boolean - whether to initialize any new collections in arango
-* `reset` - optional - boolean - whether to completely reset the spec data (do a clean download and overwrite)
+* `init_collections` - optional - boolean - defaults to true - whether to initialize any new collections in arango
+* `spec_url` - optional - string - the specific url of the release to download and use (as a tarball). If left blank, then the latest release from github is used (not including any pre-releases or drafts).
+
+Every call to update specs will reset the spec data (do a clean download and overwrite).
 
 ## Python client API
 

--- a/src/relation_engine_server/server.py
+++ b/src/relation_engine_server/server.py
@@ -132,7 +132,9 @@ def refresh_specs():
     Auth: admin
     """
     auth.require_auth_token(['RE_ADMIN'])
-    pull_spec.download_latest(init_collections='init_collections' in flask.request.args)
+    init_collections = 'init_collections' in flask.request.args
+    release_url = flask.request.args.get('release_url')
+    pull_spec.download_specs(init_collections, release_url)
     return flask.jsonify({'status': 'updated'})
 
 

--- a/src/relation_engine_server/utils/pull_spec.py
+++ b/src/relation_engine_server/utils/pull_spec.py
@@ -8,7 +8,7 @@ from . import arango_client, spec_loader
 from .config import get_config
 
 
-def download_latest(init_collections=True):
+def download_specs(init_collections=True, release_url=None):
     """Check and download the latest spec and extract it to the spec path."""
     config = get_config()
     # Remove the spec directory, ignoring if it is already missing
@@ -19,6 +19,8 @@ def download_latest(init_collections=True):
     if 'SPEC_RELEASE_PATH' in os.environ:
         _extract_tarball(os.environ['SPEC_RELEASE_PATH'], config['spec_paths']['root'])
     else:
+        if release_url:
+            tarball_url = release_url
         if 'SPEC_RELEASE_URL' in os.environ:
             tarball_url = os.environ['SPEC_RELEASE_URL']
         else:
@@ -40,13 +42,14 @@ def download_latest(init_collections=True):
 
 
 def _fetch_github_release_url():
+    """Find the latest relation engine spec release using the github api."""
     config = get_config()
     # Download information about the latest release
     release_resp = requests.get(config['spec_url'] + '/releases/latest')
     release_info = release_resp.json()
     if release_resp.status_code != 200:
         # This may be a github API rate usage limit, or some other error
-        raise Exception(release_info['message'])
+        raise RuntimeError(release_info['message'])
     return release_info['tarball_url']
 
 


### PR DESCRIPTION
This is a minimalistic way for us to be able to update the specs to prerelease, or even roll back the specs to previous versions, by specifying the url of the release in the url params to /api/update_specs

I'm thinking about how to test this.. in the mean time would appreciate any feedback