### PR TITLE
Add a versioning system

### DIFF
--- a/src/relation_engine_server/api_modules/api_v1.py
+++ b/src/relation_engine_server/api_modules/api_v1.py
@@ -112,4 +112,3 @@ endpoints = {
     'specs': {'handler': update_specs, 'methods': {'PUT'}},
     'documents': {'handler': save_documents, 'methods': {'PUT'}}
 }
-deprecations = {}  # type: ignore

--- a/src/relation_engine_server/api_modules/api_v1.py
+++ b/src/relation_engine_server/api_modules/api_v1.py
@@ -1,0 +1,115 @@
+import flask
+from ..utils import arango_client, spec_loader, auth, bulk_import, pull_spec, config, parse_json
+from ..exceptions import InvalidParameters
+
+
+def show_views():
+    """Handle /views."""
+    name = flask.request.args.get('name')
+    if name:
+        return {'view': spec_loader.get_view(name)}
+    return spec_loader.get_view_names()
+
+
+def show_schemas():
+    """Handle /schemas."""
+    name = flask.request.args.get('name')
+    if name:
+        return spec_loader.get_schema(name)
+    return spec_loader.get_schema_names()
+
+
+def run_query():
+    """
+    Run a stored view as a query against the database.
+    Auth:
+     - only kbase re admins for ad-hoc queries
+     - public for views (views will have access controls within them based on params)
+    """
+    json_body = parse_json.get_json_body() or {}
+    # Don't allow the user to set the special 'ws_ids' field
+    json_body['ws_ids'] = []
+    auth_token = auth.get_auth_header()
+    # Fetch any authorized workspace IDs using a KBase auth token, if present
+    json_body['ws_ids'] = auth.get_workspace_ids(auth_token)
+    # fetch number of documents to return
+    batch_size = int(flask.request.args.get('batch_size', 100))
+    if 'query' in json_body:
+        # Run an adhoc query for a sysadmin
+        auth.require_auth_token(roles=['RE_ADMIN'])
+        query_text = json_body['query']
+        del json_body['query']
+        resp_body = arango_client.run_query(query_text=query_text,
+                                            bind_vars=json_body,
+                                            batch_size=batch_size)
+        return resp_body
+    if 'view' in flask.request.args:
+        # Run a query from a view name
+        view_name = flask.request.args['view']
+        view_source = spec_loader.get_view(view_name)
+        resp_body = arango_client.run_query(query_text=view_source,
+                                            bind_vars=json_body,
+                                            batch_size=batch_size)
+        return resp_body
+    if 'cursor_id' in flask.request.args:
+        # Run a query from a cursor ID
+        cursor_id = flask.request.args['cursor_id']
+        resp_body = arango_client.run_query(cursor_id=cursor_id)
+        return resp_body
+    # No valid options were passed
+    raise InvalidParameters('Pass in a view or a cursor_id')
+
+
+def update_specs():
+    """
+    Manually check for updates, download spec releases, and init new collections.
+    Auth: admin
+    """
+    auth.require_auth_token(['RE_ADMIN'])
+    init_collections = 'init_collections' in flask.request.args
+    release_url = flask.request.args.get('release_url')
+    pull_spec.download_specs(init_collections, release_url)
+    return {'status': 'updated'}
+
+
+def save_documents():
+    """
+    Create, update, or replace many documents in a batch.
+    Auth: admin
+    """
+    auth.require_auth_token(['RE_ADMIN'])
+    collection_name = flask.request.args['collection']
+    query = {'collection': collection_name, 'type': 'documents'}
+    if flask.request.args.get('display_errors'):
+        # Display an array of error messages
+        query['details'] = 'true'
+    if flask.request.args.get('on_duplicate'):
+        query['onDuplicate'] = flask.request.args['on_duplicate']
+    if flask.request.args.get('overwrite'):
+        query['overwrite'] = 'true'
+    resp_text = bulk_import.bulk_import(query)
+    return resp_text
+
+
+def show_config():
+    """Show public config data."""
+    conf = config.get_config()
+    return {
+        'auth_url': conf['auth_url'],
+        'workspace_url': conf['workspace_url'],
+        'kbase_endpoint': conf['kbase_endpoint'],
+        'db_url': conf['db_url'],
+        'db_name': conf['db_name'],
+        'spec_url': conf['spec_url']
+    }
+
+
+endpoints = {
+    'query_results': {'handler': run_query, 'methods': {'POST'}},
+    'specs/schemas': {'handler': show_schemas},
+    'specs/views': {'handler': show_views},
+    'config': {'handler': show_config},
+    'specs': {'handler': update_specs, 'methods': {'PUT'}},
+    'documents': {'handler': save_documents, 'methods': {'PUT'}}
+}
+deprecations = {}  # type: ignore

--- a/src/relation_engine_server/exceptions.py
+++ b/src/relation_engine_server/exceptions.py
@@ -3,7 +3,16 @@ Collection of exception classes for the Relation Engine server.
 """
 
 
+class InvalidParameters(Exception):
+    """Invalid request parameters."""
+
+    def __init__(self, msg): self.msg = msg
+
+    def __str__(self): return self.msg
+
+
 class MissingHeader(Exception):
+    """Missing required header ina  request."""
 
     def __init__(self, header_name):
         self.header_name = header_name
@@ -13,6 +22,7 @@ class MissingHeader(Exception):
 
 
 class UnauthorizedAccess(Exception):
+    "Authentication failed for an authorization header."""
 
     def __init__(self, auth_url, response):
         self.auth_url = auth_url

--- a/src/relation_engine_server/exceptions.py
+++ b/src/relation_engine_server/exceptions.py
@@ -12,7 +12,7 @@ class InvalidParameters(Exception):
 
 
 class MissingHeader(Exception):
-    """Missing required header ina  request."""
+    """Missing required header in a request."""
 
     def __init__(self, header_name):
         self.header_name = header_name

--- a/src/relation_engine_server/server.py
+++ b/src/relation_engine_server/server.py
@@ -46,7 +46,6 @@ def api_call(path):
     Versioning system:
     - Every API version is a discrete python module that contains an 'endpoints' dictionary.
     - Versions are simple incrementing integers. We only need a new version for breaking changes.
-    Note that endpoints cannot be removed with new versions, only overwritten or added.
     """
     path_parts = path.split('/')
     version_int = _get_version(path_parts[0])

--- a/src/relation_engine_server/server.py
+++ b/src/relation_engine_server/server.py
@@ -1,4 +1,5 @@
 """The main entrypoint for running the Flask server."""
+import re
 import flask
 import json
 import os
@@ -6,8 +7,13 @@ from uuid import uuid4
 import traceback
 from jsonschema.exceptions import ValidationError
 
-from .exceptions import MissingHeader, UnauthorizedAccess
-from .utils import arango_client, spec_loader, auth, bulk_import, pull_spec, config
+from .exceptions import MissingHeader, UnauthorizedAccess, InvalidParameters
+from .utils import arango_client, spec_loader
+from .api_modules import api_v1
+
+# All api version modules, from oldest to newest
+_API_VERSIONS = [api_v1.endpoints]
+_API_DEPRECATIONS = [api_v1.deprecations]
 
 app = flask.Flask(__name__)
 app.config['DEBUG'] = os.environ.get('FLASK_DEBUG', True)
@@ -25,137 +31,90 @@ def root():
         commit_hash = 'unknown'
     arangodb_status = arango_client.server_status()
     repo_url = 'https://github.com/kbase/relation_engine_api.git'
-    return flask.jsonify({
+    body = {
         'arangodb_status': arangodb_status,
         'commit_hash': commit_hash,
         'repo_url': repo_url
-    })
+    }
+    return _json_resp(body)
 
 
-@app.route('/config', methods=['GET'])
-def show_config():
-    conf = config.get_config()
-    return flask.jsonify({
-        'auth_url': conf['auth_url'],
-        'workspace_url': conf['workspace_url'],
-        'kbase_endpoint': conf['kbase_endpoint'],
-        'db_url': conf['db_url'],
-        'db_name': conf['db_name'],
-        'spec_url': conf['spec_url']
-    })
-
-
-@app.route('/api/views', methods=['GET'])
-def show_views():
+@app.route('/api/<path:path>', methods=['GET', 'PUT', 'POST', 'DELETE'])
+def api_call(path):
     """
-    Fetch view names and content.
-    Auth: public
+    Handle an api request, dispatching it to the appropriate versioned module.
+
+    Versioning system:
+    - Every API version is a discrete python module that contains an 'endpoints' dictionary.
+    - New versions don't need to redefine previous endpoints.
+        - If an endpoint is not defined, we fall back to a previous version.
+    - New versions can overwrite existing methods and add new ones.
+    - Versions are simple incrementing integers. We only need a new version for breaking changes.
+    - New modules can deprecate paths by putting them under the 'deprecations' key
+    Note that endpoints cannot be removed with new versions, only overwritten or added.
     """
-    return flask.jsonify(spec_loader.get_view_names())
+    path_parts = path.split('/')
+    version_int = _get_version(path_parts[0])
+    # Get the path and version number
+    api_path = '/'.join(path_parts[1:])
+    # Flag for whether the endpoint we find is deprecated
+    deprecated = False
+    # Find our method in the various versioned modules
+    # If it is not present in a later version, fall back to a previous version
+    # Iterates by starting at (version-1), stopping at 0, and stepping backwards
+    # Note: the mypy type checker has difficulties with the path_funcs dicts, so we ignore type checking below
+    for ver in range(version_int - 1, -1, -1):
+        path_funcs = _API_VERSIONS[ver]
+        deprecations = _API_DEPRECATIONS[ver]
+        if api_path in deprecations:
+            # We found a deprecation flag on the endpoint
+            deprecated = True
+        if api_path in path_funcs:
+            methods = path_funcs[api_path].get('methods', {'GET'})  # type: ignore
+            # Mypy is not able to infer that `methods` will always be a set
+            if flask.request.method not in methods:  # type: ignore
+                return (flask.jsonify({'error': '405 - Method not allowed.'}), 405)
+            # We found a matching function for the endpoint and method
+            func = path_funcs[api_path]['handler']  # type: ignore
+            # Mypy is not able to infer that this is a function
+            result = func()  # type: ignore
+            return _json_resp(result, 200, deprecated)
+    body = {'error': f'path not found: {api_path}'}
+    return _json_resp(body, 404)
 
 
-@app.route('/api/query_results', methods=['POST'])
-def run_query():
-    """
-    Run a stored view as a query against the database.
-    Auth:
-     - only kbase re admins for ad-hoc queries
-     - public for views (views will have access controls within them based on params)
-    """
-    # Note that flask.request.json only works if the request Content-Type is application/json
-    json_body = json.loads(flask.request.get_data() or '{}')
-    # Don't allow the user to set the special 'ws_ids' field
-    json_body['ws_ids'] = []
-    auth_token = auth.get_auth_header()
-    # Fetch any authorized workspace IDs using a KBase auth token, if present
-    json_body['ws_ids'] = auth.get_workspace_ids(auth_token)
-    # fetch number of documents to return
-    batch_size = int(flask.request.args.get('batch_size', 100))
-    if 'query' in json_body:
-        # Run an adhoc query for a sysadmin
-        auth.require_auth_token(roles=['RE_ADMIN'])
-        query_text = json_body['query']
-        del json_body['query']
-        resp_body = arango_client.run_query(query_text=query_text,
-                                            bind_vars=json_body,
-                                            batch_size=batch_size)
-        return flask.jsonify(resp_body)
-    if 'view' in flask.request.args:
-        # Run a query from a view name
-        view_name = flask.request.args['view']
-        view_source = spec_loader.get_view(view_name)
-        resp_body = arango_client.run_query(query_text=view_source,
-                                            bind_vars=json_body,
-                                            batch_size=batch_size)
-        return flask.jsonify(resp_body)
-    if 'cursor_id' in flask.request.args:
-        # Run a query from a cursor ID
-        cursor_id = flask.request.args['cursor_id']
-        resp_body = arango_client.run_query(cursor_id=cursor_id)
-        return flask.jsonify(resp_body)
-    # No valid options were passed
-    resp_body = {'error': 'Pass in a view or a cursor_id'}
-    return (flask.jsonify(resp_body), 400)
+def _get_version(version_str):
+    """From a list of path parts, initialize and validate a version int for the api."""
+    ver_len = len(_API_VERSIONS)
+    # Make sure the version looks like 'v12'
+    if not re.match(r'^v\d+$', version_str):
+        raise InvalidParameters('Make a request with the format /api/<version>/<path...>')
+    # Parse to an int
+    version_int = int(version_str.replace('v', ''))
+    # Make sure the version number is valid
+    if version_int <= 0:
+        raise InvalidParameters('API version must be > 0')
+    if version_int > ver_len:
+        raise InvalidParameters(f'Invalid api version; max is {ver_len}')
+    return version_int
 
 
-@app.route('/api/schemas', methods=['GET'])
-def show_schemas():
-    """
-    Fetch schema names and content.
-    Auth: public
-    """
-    return flask.jsonify(spec_loader.get_schema_names())
-
-
-@app.route('/api/schemas/<name>', methods=['GET'])
-def show_schema(name):
-    """
-    Fetch the JSON for a single schema.
-    Auth: public
-    """
-    return flask.jsonify(spec_loader.get_schema(name))
-
-
-@app.route('/api/views/<name>', methods=['GET'])
-def show_view(name):
-    """
-    Fetch the AQL for a single view.
-    Auth: public
-    """
-    return flask.Response(spec_loader.get_view(name), mimetype='text/plain')
-
-
-@app.route('/api/update_specs', methods=['GET'])
-def refresh_specs():
-    """
-    Manually check for updates, download spec releases, and init new collections.
-    Auth: admin
-    """
-    auth.require_auth_token(['RE_ADMIN'])
-    init_collections = 'init_collections' in flask.request.args
-    release_url = flask.request.args.get('release_url')
-    pull_spec.download_specs(init_collections, release_url)
-    return flask.jsonify({'status': 'updated'})
-
-
-@app.route('/api/documents', methods=['PUT'])
-def save_documents():
-    """
-    Create, update, or replace many documents in a batch.
-    Auth: admin
-    """
-    auth.require_auth_token(['RE_ADMIN'])
-    collection_name = flask.request.args['collection']
-    query = {'collection': collection_name, 'type': 'documents'}
-    if flask.request.args.get('display_errors'):
-        # Display an array of error messages
-        query['details'] = 'true'
-    if flask.request.args.get('on_duplicate'):
-        query['onDuplicate'] = flask.request.args['on_duplicate']
-    if flask.request.args.get('overwrite'):
-        query['overwrite'] = 'true'
-    resp_text = bulk_import.bulk_import(query)
-    return resp_text
+def _json_resp(result, status=200, deprecated=False):
+    """Send a json response back to the requester with the proper headers."""
+    resp = flask.Response(json.dumps(result))
+    resp.status_code = status
+    if deprecated:
+        # Add a deprecation warning in the headers
+        resp.headers['Warning'] = 'DEPRECATED'
+    print(' '.join([flask.request.method, flask.request.path, '->', resp.status]))
+    # Enable CORS
+    resp.headers['Access-Control-Allow-Origin'] = '*'
+    env_allowed_headers = os.environ.get('HTTP_ACCESS_CONTROL_REQUEST_HEADERS', 'authorization')
+    resp.headers['Access-Control-Allow-Headers'] = env_allowed_headers
+    # Set JSON content type and response length
+    resp.headers['Content-Type'] = 'application/json'
+    resp.headers['Content-Length'] = resp.calculate_content_length()
+    return resp
 
 
 @app.errorhandler(json.decoder.JSONDecodeError)
@@ -168,7 +127,7 @@ def json_decode_error(err):
         'lineno': err.lineno,
         'colno': err.colno
     }
-    return (flask.jsonify(resp), 400)
+    return _json_resp(resp, 400)
 
 
 @app.errorhandler(arango_client.ArangoServerError)
@@ -177,18 +136,22 @@ def arango_server_error(err):
         'error': str(err),
         'arango_message': err.resp_json['errorMessage']
     }
-    return (flask.jsonify(resp), 400)
+    return _json_resp(resp, 400)
+
+
+@app.errorhandler(InvalidParameters)
+def invalid_params(err):
+    """Invalid request body json params."""
+    resp = {'error': str(err)}
+    return _json_resp(resp, 400)
 
 
 @app.errorhandler(spec_loader.SchemaNonexistent)
 @app.errorhandler(spec_loader.ViewNonexistent)
 def view_does_not_exist(err):
     """General error cases."""
-    resp = {
-        'error': str(err),
-        'name': err.name
-    }
-    return (flask.jsonify(resp), 400)
+    resp = {'error': str(err), 'name': err.name}
+    return _json_resp(resp, 400)
 
 
 @app.errorhandler(ValidationError)
@@ -201,7 +164,7 @@ def validation_error(err):
         'validator_value': err.validator_value,
         'schema': err.schema
     }
-    return (flask.jsonify(resp), 400)
+    return _json_resp(resp, 400)
 
 
 @app.errorhandler(UnauthorizedAccess)
@@ -211,22 +174,22 @@ def unauthorized_access(err):
         'auth_url': err.auth_url,
         'auth_response': err.response
     }
-    return (flask.jsonify(resp), 403)
+    return _json_resp(resp, 403)
 
 
 @app.errorhandler(404)
 def page_not_found(err):
-    return (flask.jsonify({'error': '404 - Not found.'}), 404)
+    return _json_resp({'error': '404 - Not found.'}, 404)
 
 
 @app.errorhandler(405)
 def method_not_allowed(err):
-    return (flask.jsonify({'error': '405 - Method not allowed.'}), 405)
+    return _json_resp({'error': '405 - Method not allowed.'}, 405)
 
 
 @app.errorhandler(MissingHeader)
 def generic_400(err):
-    return (flask.jsonify({'error': str(err)}), 400)
+    return _json_resp({'error': str(err)}, 400)
 
 
 # Any other unhandled exceptions -> 500
@@ -242,18 +205,4 @@ def server_error(err):
     # if os.environ.get('FLASK_DEBUG'):  TODO
     resp['error_class'] = err.__class__.__name__
     resp['error_details'] = str(err)
-    return (flask.jsonify(resp), 500)
-
-
-@app.after_request
-def after_request(response):
-    """Actions to perform on the response after the request handler finishes running."""
-    print(' '.join([flask.request.method, flask.request.path, '->', response.status]))
-    # Enable CORS
-    response.headers['Access-Control-Allow-Origin'] = '*'
-    env_allowed_headers = os.environ.get('HTTP_ACCESS_CONTROL_REQUEST_HEADERS', 'authorization')
-    response.headers['Access-Control-Allow-Headers'] = env_allowed_headers
-    # Set JSON content type and response length
-    response.headers['Content-Type'] = 'application/json'
-    response.headers['Content-Length'] = response.calculate_content_length()
-    return response
+    return _json_resp(resp, 500)

--- a/src/relation_engine_server/server.py
+++ b/src/relation_engine_server/server.py
@@ -47,26 +47,23 @@ def api_call(path):
     - Every API version is a discrete python module that contains an 'endpoints' dictionary.
     - Versions are simple incrementing integers. We only need a new version for breaking changes.
     """
+    # Get the path and version number
     path_parts = path.split('/')
     version_int = _get_version(path_parts[0])
-    # Get the path and version number
     api_path = '/'.join(path_parts[1:])
     # Find our method in the various versioned modules
-    # If it is not present in a later version, fall back to a previous version
-    # Iterates by starting at (version-1), stopping at 0, and stepping backwards
-    # Note: the mypy type checker has difficulties with the endpoints dicts, so we ignore type checking below
-    endpoints = _API_VERSIONS[version_int - 1]
+    # Note: the mypy type checker has difficulties with the endpoints dict, so we ignore type checking below
+    endpoints = _API_VERSIONS[version_int - 1]  # index 0 == version 1
     if api_path not in endpoints:
-        body = {'error': f'path not found: {api_path}'}
+        body = {'error': f'Path not found: {api_path}.'}
         return _json_resp(body, 404)
     methods = endpoints[api_path].get('methods', {'GET'})  # type: ignore
     # Mypy is not able to infer that `methods` will always be a set
     if flask.request.method not in methods:  # type: ignore
         return (flask.jsonify({'error': '405 - Method not allowed.'}), 405)
     # We found a matching function for the endpoint and method
-    func = endpoints[api_path]['handler']  # type: ignore
     # Mypy is not able to infer that this is a function
-    result = func()  # type: ignore
+    result = endpoints[api_path]['handler']()  # type: ignore
     return _json_resp(result, 200)
 
 

--- a/src/relation_engine_server/server.py
+++ b/src/relation_engine_server/server.py
@@ -56,7 +56,7 @@ def api_call(path):
     # If it is not present in a later version, fall back to a previous version
     # Iterates by starting at (version-1), stopping at 0, and stepping backwards
     # Note: the mypy type checker has difficulties with the endpoints dicts, so we ignore type checking below
-    endpoints = _API_VERSIONS[version_int]
+    endpoints = _API_VERSIONS[version_int - 1]
     if api_path not in endpoints:
         body = {'error': f'path not found: {api_path}'}
         return _json_resp(body, 404)

--- a/src/relation_engine_server/utils/parse_json.py
+++ b/src/relation_engine_server/utils/parse_json.py
@@ -1,0 +1,11 @@
+import json
+import flask
+
+
+def get_json_body():
+    """Parse json out of a request body, if present."""
+    json_body = None  # type: ignore
+    req_data = flask.request.get_data()
+    if req_data:
+        json_body = json.loads(req_data)
+    return json_body

--- a/src/relation_engine_server/utils/parse_json.py
+++ b/src/relation_engine_server/utils/parse_json.py
@@ -3,7 +3,10 @@ import flask
 
 
 def get_json_body():
-    """Parse json out of a request body, if present."""
+    """
+    Parse json out of a request body, if present.
+    If the request body is empty, we return None rather than throwing any parsing errors.
+    """
     json_body = None  # type: ignore
     req_data = flask.request.get_data()
     if req_data:


### PR DESCRIPTION
This is what I came up with regarding a system for url-based versioning of this api while keeping the code dry. New versions basically can deprecate or shadow the paths of old versions.

This has some breaking changes on the admin/config paths: eg. "/api/view/name" is now "/api/views?name=name". I'm positive that no code depends on these endpoints so I think it's safe. Except for changing paths from eg. "/api/query_results" to "/api/v1/query_results", all the rest of the api is the same as before.

And of course this will break clients that use the "api/path" calls currently (KE apps and landing page ui). We'll just have to update those. Going forward, this will give backwards compatibility for any modified endpoints.