### PR TITLE
Add automatic sharding for new collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,17 @@ save_results = rec.save_documents(
 
 Where the file contains multiple JSON documents separated by line-breaks.
 
+## Administration
+
+The following environment variables should be configured:
+
+* `KBASE_AUTH_URL` - url of the KBase authentication (auth2) server to use
+* `SHARD_COUNT` - number of shards to use when creating new collections
+* `KBASE_WORKSPACE_URL` - url of the KBase workspace server to use (for authenticating workspace access)
+* `DB_URL` - url of the arangodb database to use for http API access
+* `DB_USER` - username for the arangodb database
+* `DB_PASS` - password for the arangodb database
+
 ## Development
 
 Copy `.env.example` to `.env`. Start the server with `docker-compose up`.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -26,14 +26,6 @@ services:
       - DB_USER=root
       - DB_PASS=password
 
-  # For running (and testing against) ArangoDB
-  arangodb:
-    image: arangodb:3.4
-    ports:
-      - 8529:8529
-    environment:
-      - ARANGO_ROOT_PASSWORD=password
-
   # A mock kbase auth server (see src/test/mock_auth/endpoints.json)
   auth:
     image: mockservices/mock_json_service
@@ -45,3 +37,12 @@ services:
     image: mockservices/mock_json_service
     volumes:
       - ${PWD}/src/test/mock_workspace:/config
+
+  # Arangodb server in cluster mode
+  arangodb:
+    image: arangodb:3.4
+    ports:
+      - 8529:8529
+    environment:
+      - ARANGO_ROOT_PASSWORD=password
+    command: arangodb --starter.local

--- a/src/relation_engine_server/utils/arango_client.py
+++ b/src/relation_engine_server/utils/arango_client.py
@@ -1,6 +1,7 @@
 """
 Make ajax requests to the ArangoDB server.
 """
+import os
 import requests
 import json
 
@@ -74,7 +75,9 @@ def create_collection(name, is_edge):
     """
     Create a single collection by name using some basic defaults.
     We ignore duplicates. For any other server error, an exception is thrown.
+    Shard the new collection based on the number of db nodes (10 shards for each).
     """
+    num_shards = os.environ.get('SHARD_COUNT', 30)
     config = get_config()
     url = config['db_url'] + '/_api/collection'
     # collection types:
@@ -84,7 +87,8 @@ def create_collection(name, is_edge):
     data = json.dumps({
         'keyOptions': {'allowUserKeys': True},
         'name': name,
-        'type': collection_type
+        'type': collection_type,
+        'numberOfShards': num_shards
     })
     resp = requests.post(url, data, auth=(config['db_user'], config['db_pass'])).json()
     if resp['error']:


### PR DESCRIPTION
- Create collections using a configurable number of shards with a fallback.
- Make the arangodb instance in the test docker-compose.yaml a cluster for more accurate testing (i found the `--starter.local` flag which creates a cluster on one node, very handy for testing)

- [x] I updated the README.md docs to reflect this change.
- [x] This is either not a breaking API change, or I incremented the API version.