### PR TITLE
Add a docker tag for the docker hub build

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,6 +326,8 @@ See the [Contribution Guidelines](/.github/CONTRIBUTING.md).
 
 The docker image is pushed to Docker Hub when new commits are made to master. The script that runs when pushing to docker hub is found in `hooks/build`.
 
+Commits to the master branch build to the `latest` tag on docker hub. Commits to any other branch build to images on docker hub tagged with the name of the branch.
+
 ## Project anatomy
 
 * Source code is in `./src`

--- a/hooks/build
+++ b/hooks/build
@@ -8,7 +8,11 @@ echo "Build hook running"
 export BRANCH=${TRAVIS_BRANCH:-`git symbolic-ref --short HEAD`}
 export DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"`
 export COMMIT=${TRAVIS_COMMIT:-`git rev-parse --short HEAD`}
+export DOCKER_TAG=$BRANCH
+if [ $BRANCH = "master"]; then
+  DOCKER_TAG="latest"
+fi
 docker build --build-arg BUILD_DATE=$DATE \
              --build-arg VCS_REF=$COMMIT \
              --build-arg BRANCH=$BRANCH \
-             -t ${IMAGE_NAME} .
+             -t ${IMAGE_NAME}:${DOCKER_TAG} .


### PR DESCRIPTION
- Build non-master branches to specific tags on docker hub.
- Build the master branch to the "latest" tag on docker hub.

- [ ] I updated the README.md docs to reflect this change.
- [ ] This is either not a breaking API change, or I incremented the API version.