### PR TITLE
Backwards compatibility

### DIFF
--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-flake8 --max-complexity 5 src
+flake8 src
 mypy --ignore-missing-imports src
 python -m pyflakes src
 bandit -r src

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-flake8 src
+flake8 --max-complexity 5 src
 mypy --ignore-missing-imports src
 python -m pyflakes src
 bandit -r src

--- a/src/test/test_api_v1.py
+++ b/src/test/test_api_v1.py
@@ -426,3 +426,18 @@ class TestApi(unittest.TestCase):
         ).json()
         self.assertTrue(resp['error'])
         self.assertTrue('read only' in resp['arango_message'])
+
+    def test_no_version_in_path(self):
+        """Test that leaving out api version in the path falls back to v1"""
+        # TODO XXX temporary
+        save_test_docs(1)
+        query = 'let ws_ids = @ws_ids for v in test_vertex sort rand() limit @count return v._id'
+        url = '/'.join([URL, 'api'])  # Leaving off version
+        resp = requests.post(
+            url + '/query_results',
+            params={},
+            headers=HEADERS_ADMIN,
+            data=json.dumps({'query': query, 'count': 1})
+        ).json()
+        self.assertEqual(resp['count'], 1)
+        self.assertEqual(len(resp['results']), 1)


### PR DESCRIPTION
Temporarily version-less api requests for backwards compatibility while we update the frontends.

- [x] I updated the README.md docs to reflect this change.
- [x] This is either not a breaking API change, or I incremented the API version.
