### PR TITLE
Get full count

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,4 @@
 
 - [ ] I updated the README.md docs to reflect this change.
-- [ ] This is either not a breaking API change, or I incremented the API version.
+- [ ] This is not a breaking API change OR 
+- [ ] This is a breaking API change and I have incremented the API version.

--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ curl -X POST -d '{"argument": "value"}' {root_url}/api/v1/query_results?view=exa
 _Query params_
 * `view` - required - string - name of the view to run as a query against the database
 * `cursor_id` - required - string - ID of a cursor that was returned from a previous query with >100 results
+* `full_count` - optional - bool - If true, return a count of the total documents before any LIMIT is applied (for example, in pagination). This might make some queries run more slowly
 
 Pass one of `view` or `cursor_id` -- not both.
 

--- a/src/relation_engine_server/api_modules/api_v1.py
+++ b/src/relation_engine_server/api_modules/api_v1.py
@@ -34,6 +34,7 @@ def run_query():
     json_body['ws_ids'] = auth.get_workspace_ids(auth_token)
     # fetch number of documents to return
     batch_size = int(flask.request.args.get('batch_size', 100))
+    full_count = flask.request.args.get('full_count', False)
     if 'query' in json_body:
         # Run an adhoc query for a sysadmin
         auth.require_auth_token(roles=['RE_ADMIN'])
@@ -41,7 +42,8 @@ def run_query():
         del json_body['query']
         resp_body = arango_client.run_query(query_text=query_text,
                                             bind_vars=json_body,
-                                            batch_size=batch_size)
+                                            batch_size=batch_size,
+                                            full_count=full_count)
         return resp_body
     if 'view' in flask.request.args:
         # Run a query from a view name
@@ -49,7 +51,8 @@ def run_query():
         view_source = spec_loader.get_view(view_name)
         resp_body = arango_client.run_query(query_text=view_source,
                                             bind_vars=json_body,
-                                            batch_size=batch_size)
+                                            batch_size=batch_size,
+                                            full_count=full_count)
         return resp_body
     if 'cursor_id' in flask.request.args:
         # Run a query from a cursor ID

--- a/src/relation_engine_server/utils/arango_client.py
+++ b/src/relation_engine_server/utils/arango_client.py
@@ -29,7 +29,8 @@ def run_query(query_text=None, cursor_id=None, bind_vars=None, batch_size=100):
     url = config['db_url'] + '/_api/cursor'
     req_json = {
         'batchSize': min(5000, batch_size),
-        'memoryLimit': 16000000000  # 16gb
+        'memoryLimit': 16000000000,  # 16gb
+        'options': {'fullCount': True}
     }
     if cursor_id:
         method = 'PUT'

--- a/src/relation_engine_server/utils/arango_client.py
+++ b/src/relation_engine_server/utils/arango_client.py
@@ -23,14 +23,13 @@ def server_status():
         return 'unknown_failure'
 
 
-def run_query(query_text=None, cursor_id=None, bind_vars=None, batch_size=100):
+def run_query(query_text=None, cursor_id=None, bind_vars=None, batch_size=100, full_count=False):
     """Run a query using the arangodb http api. Can return a cursor to get more results."""
     config = get_config()
     url = config['db_url'] + '/_api/cursor'
     req_json = {
         'batchSize': min(5000, batch_size),
         'memoryLimit': 16000000000,  # 16gb
-        'options': {'fullCount': True}
     }
     if cursor_id:
         method = 'PUT'
@@ -39,6 +38,8 @@ def run_query(query_text=None, cursor_id=None, bind_vars=None, batch_size=100):
         method = 'POST'
         req_json['count'] = True
         req_json['query'] = query_text
+        if full_count:
+            req_json['options'] = {'fullCount': True}
         if bind_vars:
             req_json['bindVars'] = bind_vars
     # Initialize the readonly user
@@ -50,10 +51,8 @@ def run_query(query_text=None, cursor_id=None, bind_vars=None, batch_size=100):
         data=json.dumps(req_json),
         auth=(config['db_readonly_user'], config['db_readonly_pass'])
     )
-    if not resp.ok:
-        raise ArangoServerError(resp.text)
     resp_json = resp.json()
-    if resp_json['error']:
+    if not resp.ok or resp_json['error']:
         raise ArangoServerError(resp.text)
     return {
         'results': resp_json['result'],
@@ -155,7 +154,7 @@ def _init_readonly_user():
         data='{"grant": "ro"}',
         auth=(config['db_user'], config['db_pass'])
     )
-    if resp.status_code != 200:
+    if not resp.ok:
         raise ArangoServerError(resp.text)
 
 

--- a/src/test/test_api_v1.py
+++ b/src/test/test_api_v1.py
@@ -284,7 +284,7 @@ class TestApi(unittest.TestCase):
         save_test_docs(count=20)
         resp = requests.post(
             API_URL + '/query_results',
-            params={'view': 'list_test_vertices', 'batch_size': 10}
+            params={'view': 'list_test_vertices', 'batch_size': 10, 'full_count': True}
         ).json()
         self.assertTrue(resp['cursor_id'])
         self.assertEqual(resp['has_more'], True)

--- a/src/test/test_api_v1.py
+++ b/src/test/test_api_v1.py
@@ -289,6 +289,7 @@ class TestApi(unittest.TestCase):
         self.assertTrue(resp['cursor_id'])
         self.assertEqual(resp['has_more'], True)
         self.assertEqual(resp['count'], 20)
+        self.assertEqual(resp['stats']['fullCount'], 20)
         self.assertTrue(len(resp['results']), 10)
         cursor_id = resp['cursor_id']
         resp = requests.post(
@@ -296,6 +297,7 @@ class TestApi(unittest.TestCase):
             params={'cursor_id': cursor_id}
         ).json()
         self.assertEqual(resp['count'], 20)
+        self.assertEqual(resp['stats']['fullCount'], 20)
         self.assertEqual(resp['has_more'], False)
         self.assertEqual(resp['cursor_id'], None)
         self.assertTrue(len(resp['results']), 10)


### PR DESCRIPTION
This can be a pretty useful option for queries using pagination. I made it an optional flag because I don't know how badly it will affect performance for some of the existing graph queries

- [X] I updated the README.md docs to reflect this change.
- [X] This is either not a breaking API change, or I incremented the API version.
