### PR TITLE
Add basics of jinja templating support with initial tests. WIP.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,3 +2,9 @@
 
 test:
 	docker-compose run web sh scripts/run_tests.sh
+
+reset:
+	docker-compose down
+	docker-compose rm -vf
+	docker-compose build --no-cache
+	docker-compose up

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ simplejson==3.16.0
 python-dotenv==0.9.1
 requests==2.20.0
 jsonschema==2.6.0
+Jinja2==2.10

--- a/src/relation_engine_server/api_modules/api_v2.py
+++ b/src/relation_engine_server/api_modules/api_v2.py
@@ -1,0 +1,61 @@
+import flask
+import jinja2
+
+from . import api_v1
+
+from ..utils import arango_client, spec_loader, auth, parse_json
+from ..exceptions import InvalidParameters
+
+
+def run_query():
+    """
+    Run a stored query from the spec repo.
+    Auth:
+     - only kbase re admins for ad-hoc queries
+     - public for views (views will have access controls within them based on params)
+    """
+    json_body = parse_json.get_json_body() or {}
+    if 'bind_vars' not in json_body:
+        json_body['bind_vars'] = {}
+    # Don't allow the user to set the special 'ws_ids' field
+    json_body['bind_vars']['ws_ids'] = []
+    auth_token = auth.get_auth_header()
+    # Fetch any authorized workspace IDs using a KBase auth token, if present
+    json_body['bind_vars']['ws_ids'] = auth.get_workspace_ids(auth_token)
+    # fetch number of documents to return
+    batch_size = int(flask.request.args.get('batch_size', 100))
+    if 'query' in json_body:
+        # Run an adhoc query for a sysadmin
+        auth.require_auth_token(roles=['RE_ADMIN'])
+        query_text = json_body['query']
+        resp_body = arango_client.run_query(query_text=query_text,
+                                            bind_vars=json_body['bind_vars'],
+                                            batch_size=batch_size)
+        return resp_body
+    if 'view' in flask.request.args:
+        # Run a query from a view name
+        view_name = flask.request.args['view']
+        view_str = spec_loader.get_view(view_name)
+        templ = jinja2.Environment(loader=jinja2.BaseLoader(), autoescape=True).from_string(view_str)
+        compiled_query = templ.render(**json_body.get('template_vars', {}))
+        resp_body = arango_client.run_query(query_text=compiled_query,
+                                            bind_vars=json_body['bind_vars'],
+                                            batch_size=batch_size)
+        return resp_body
+    if 'cursor_id' in flask.request.args:
+        # Run a query from a cursor ID
+        cursor_id = flask.request.args['cursor_id']
+        resp_body = arango_client.run_query(cursor_id=cursor_id)
+        return resp_body
+    # No valid options were passed
+    raise InvalidParameters('Pass in a view or a cursor_id')
+
+
+endpoints = {
+    'query_results': {'handler': run_query, 'methods': {'POST'}},
+    'specs/schemas': {'handler': api_v1.show_schemas},
+    'specs/views': {'handler': api_v1.show_views},
+    'config': {'handler': api_v1.show_config},
+    'specs': {'handler': api_v1.update_specs, 'methods': {'PUT'}},
+    'documents': {'handler': api_v1.save_documents, 'methods': {'PUT'}}
+}

--- a/src/relation_engine_server/server.py
+++ b/src/relation_engine_server/server.py
@@ -9,10 +9,10 @@ from jsonschema.exceptions import ValidationError
 
 from .exceptions import MissingHeader, UnauthorizedAccess, InvalidParameters
 from .utils import arango_client, spec_loader
-from .api_modules import api_v1
+from .api_modules import api_v1, api_v2
 
 # All api version modules, from oldest to newest
-_API_VERSIONS = [api_v1.endpoints]
+_API_VERSIONS = [api_v1.endpoints, api_v2.endpoints]
 
 app = flask.Flask(__name__)
 app.config['DEBUG'] = os.environ.get('FLASK_DEBUG', True)

--- a/src/test/test_api_v1.py
+++ b/src/test/test_api_v1.py
@@ -8,47 +8,20 @@ import requests
 import json
 import os
 
+from src.test.utils import save_test_docs, create_test_docs, create_test_edges
+
 # Use the mock auth tokens
-NON_ADMIN_TOKEN = 'non_admin_token'
-ADMIN_TOKEN = 'admin_token'
-INVALID_TOKEN = 'invalid_token'
+_NON_ADMIN_TOKEN = 'non_admin_token'
+_ADMIN_TOKEN = 'admin_token'
+_INVALID_TOKEN = 'invalid_token'
 
 # Use the docker-compose url of the running flask server
-URL = os.environ.get('TEST_URL', 'http://web:5000')
-VERSION = 'v1'
-API_URL = '/'.join([URL, 'api', VERSION])
+_URL = os.environ.get('TEST_URL', 'http://web:5000')
+_VERSION = 'v1'
+_API_URL = '/'.join([_URL, 'api', _VERSION])
 
-HEADERS_NON_ADMIN = {'Authorization': 'Bearer ' + NON_ADMIN_TOKEN, 'Content-Type': 'application/json'}
-HEADERS_ADMIN = {'Authorization': 'Bearer ' + ADMIN_TOKEN, 'Content-Type': 'application/json'}
-
-
-def create_test_docs(count):
-    """Produce some test documents."""
-    def doc(i):
-        return '{"name": "name", "_key": "%s", "is_public": true}' % i
-    return '\n'.join(doc(i) for i in range(0, count))
-
-
-def create_test_edges(count):
-    """Produce some test edges."""
-    def doc(i):
-        return '{"_from": "test_vertex/%s", "_to": "test_vertex/%s"}' % (i, i)
-    return '\n'.join(doc(i) for i in range(0, count))
-
-
-def save_test_docs(count, edges=False):
-    if edges:
-        docs = create_test_edges(count)
-        collection = 'test_edge'
-    else:
-        docs = create_test_docs(count)
-        collection = 'test_vertex'
-    return requests.put(
-        API_URL + '/documents',
-        params={'overwrite': True, 'collection': collection},
-        data=docs,
-        headers=HEADERS_ADMIN
-    ).json()
+_HEADERS_NON_ADMIN = {'Authorization': 'Bearer ' + _NON_ADMIN_TOKEN, 'Content-Type': 'application/json'}
+_HEADERS_ADMIN = {'Authorization': 'Bearer ' + _ADMIN_TOKEN, 'Content-Type': 'application/json'}
 
 
 class TestApi(unittest.TestCase):
@@ -57,22 +30,22 @@ class TestApi(unittest.TestCase):
     def setUpClass(cls):
         # Initialize collections before running any tests
         resp = requests.put(
-            API_URL + '/specs',
-            headers=HEADERS_ADMIN,
+            _API_URL + '/specs',
+            headers=_HEADERS_ADMIN,
             params={'init_collections': '1'}
         )
         print('update_specs response', resp.text)
 
     def test_root(self):
         """Test root path for api."""
-        resp = requests.get(URL + '/').json()
+        resp = requests.get(_URL + '/').json()
         self.assertEqual(resp['arangodb_status'], 'connected_authorized')
         self.assertTrue(resp['commit_hash'])
         self.assertTrue(resp['repo_url'])
 
     def test_config(self):
         """Test config fetch."""
-        resp = requests.get(API_URL + '/config').json()
+        resp = requests.get(_API_URL + '/config').json()
         self.assertTrue(len(resp['auth_url']))
         self.assertTrue(len(resp['workspace_url']))
         self.assertTrue(len(resp['kbase_endpoint']))
@@ -83,8 +56,8 @@ class TestApi(unittest.TestCase):
     def test_update_specs(self):
         """Test the endpoint that triggers an update on the specs."""
         resp = requests.put(
-            API_URL + '/specs',
-            headers=HEADERS_ADMIN,
+            _API_URL + '/specs',
+            headers=_HEADERS_ADMIN,
             params={'reset': '1', 'init_collections': '1'}
         )
         resp_json = resp.json()
@@ -93,17 +66,17 @@ class TestApi(unittest.TestCase):
 
     def test_list_views(self):
         """Test the listing out of saved AQL views."""
-        resp = requests.get(API_URL + '/specs/views').json()
+        resp = requests.get(_API_URL + '/specs/views').json()
         self.assertTrue('list_test_vertices' in resp)
 
     def test_show_view(self):
         """Test the endpoint that displays AQL source code for one view."""
-        resp = requests.get(API_URL + '/specs/views?name=list_test_vertices').text
+        resp = requests.get(_API_URL + '/specs/views?name=list_test_vertices').text
         self.assertTrue('test_vertex' in resp)
 
     def test_list_schemas(self):
         """Test the listing out of registered JSON schemas for vertices and edges."""
-        resp = requests.get(API_URL + '/specs/schemas').json()
+        resp = requests.get(_API_URL + '/specs/schemas').json()
         self.assertTrue('test_vertex' in resp['vertices'])
         self.assertTrue('test_edge' in resp['edges'])
         self.assertFalse('error' in resp)
@@ -111,41 +84,41 @@ class TestApi(unittest.TestCase):
 
     def test_show_schema(self):
         """Test the endpoint that displays the JSON source for one schema."""
-        resp = requests.get(API_URL + '/specs/schemas?name=test_edge').text
+        resp = requests.get(_API_URL + '/specs/schemas?name=test_edge').text
         self.assertTrue('_from' in resp)
-        resp = requests.get(API_URL + '/specs/schemas?name=test_vertex').text
+        resp = requests.get(_API_URL + '/specs/schemas?name=test_vertex').text
         self.assertTrue('_key' in resp)
 
     def test_save_documents_missing_auth(self):
         """Test an invalid attempt to save a doc with a missing auth token."""
         resp = requests.put(
-            API_URL + '/documents?on_duplicate=error&overwrite=true&collection'
+            _API_URL + '/documents?on_duplicate=error&overwrite=true&collection'
         ).json()
         self.assertEqual(resp['error'], 'Missing header: Authorization')
 
     def test_save_documents_invalid_auth(self):
         """Test an invalid attempt to save a doc with a bad auth token."""
         resp = requests.put(
-            API_URL + '/documents?on_duplicate=error&overwrite=true&collection',
-            headers={'Authorization': 'Bearer ' + INVALID_TOKEN}
+            _API_URL + '/documents?on_duplicate=error&overwrite=true&collection',
+            headers={'Authorization': 'Bearer ' + _INVALID_TOKEN}
         ).json()
         self.assertEqual(resp['error'], '403 - Unauthorized')
 
     def test_save_documents_non_admin(self):
         """Test an invalid attempt to save a doc as a non-admin."""
         resp = requests.put(
-            API_URL + '/documents?on_duplicate=error&overwrite=true&collection',
-            headers=HEADERS_NON_ADMIN
+            _API_URL + '/documents?on_duplicate=error&overwrite=true&collection',
+            headers=_HEADERS_NON_ADMIN
         ).json()
         self.assertEqual(resp['error'], '403 - Unauthorized')
 
     def test_save_documents_invalid_schema(self):
         """Test the case where some documents fail against their schema."""
         resp = requests.put(
-            API_URL + '/documents',
+            _API_URL + '/documents',
             params={'on_duplicate': 'ignore', 'collection': 'test_vertex'},
             data='{"name": "x"}\n{"name": "y"}',
-            headers=HEADERS_ADMIN
+            headers=_HEADERS_ADMIN
         ).json()
         self.assertEqual(resp['error'], "'_key' is a required property")
         self.assertEqual(resp['instance'], {'name': 'x'})
@@ -156,20 +129,20 @@ class TestApi(unittest.TestCase):
     def test_save_documents_missing_schema(self):
         """Test the case where the collection/schema does not exist."""
         resp = requests.put(
-            API_URL + '/documents',
+            _API_URL + '/documents',
             params={'collection': 'xyzabc'},
             data='',
-            headers=HEADERS_ADMIN
+            headers=_HEADERS_ADMIN
         ).json()
         self.assertTrue('Schema does not exist' in resp['error'])
 
     def test_save_documents_invalid_json(self):
         """Test an attempt to save documents with an invalid JSON body."""
         resp = requests.put(
-            API_URL + '/documents',
+            _API_URL + '/documents',
             params={'collection': 'test_vertex'},
             data='\n',
-            headers=HEADERS_ADMIN
+            headers=_HEADERS_ADMIN
         ).json()
         self.assertTrue('Unable to parse' in resp['error'])
         self.assertEqual(resp['pos'], 1)
@@ -177,23 +150,23 @@ class TestApi(unittest.TestCase):
 
     def test_create_documents(self):
         """Test all valid cases for saving documents."""
-        resp = save_test_docs(3)
+        resp = save_test_docs(_API_URL, 3)
         expected = {'created': 3, 'errors': 0, 'empty': 0, 'updated': 0, 'ignored': 0, 'error': False}
         self.assertEqual(resp, expected)
 
     def test_create_edges(self):
         """Test all valid cases for saving edges."""
-        resp = save_test_docs(3, edges=True)
+        resp = save_test_docs(_API_URL, 3, edges=True)
         expected = {'created': 3, 'errors': 0, 'empty': 0, 'updated': 0, 'ignored': 0, 'error': False}
         self.assertEqual(resp, expected)
 
     def test_update_documents(self):
         """Test updating existing documents."""
         resp = requests.put(
-            API_URL + '/documents',
+            _API_URL + '/documents',
             params={'on_duplicate': 'update', 'collection': 'test_vertex'},
             data=create_test_docs(3),
-            headers=HEADERS_ADMIN
+            headers=_HEADERS_ADMIN
         ).json()
         expected = {'created': 0, 'errors': 0, 'empty': 0, 'updated': 3, 'ignored': 0, 'error': False}
         self.assertEqual(resp, expected)
@@ -201,10 +174,10 @@ class TestApi(unittest.TestCase):
     def test_update_edge(self):
         """Test updating existing edge."""
         resp = requests.put(
-            API_URL + '/documents',
+            _API_URL + '/documents',
             params={'on_duplicate': 'update', 'collection': 'test_edge'},
             data=create_test_edges(3),
-            headers=HEADERS_ADMIN
+            headers=_HEADERS_ADMIN
         ).json()
         expected = {'created': 0, 'errors': 0, 'empty': 0, 'updated': 3, 'ignored': 0, 'error': False}
         self.assertEqual(resp, expected)
@@ -212,22 +185,22 @@ class TestApi(unittest.TestCase):
     def test_replace_documents(self):
         """Test replacing of existing documents."""
         resp = requests.put(
-            API_URL + '/documents',
+            _API_URL + '/documents',
             params={'on_duplicate': 'replace', 'collection': 'test_vertex'},
             data=create_test_docs(3),
-            headers=HEADERS_ADMIN
+            headers=_HEADERS_ADMIN
         ).json()
         expected = {'created': 0, 'errors': 0, 'empty': 0, 'updated': 3, 'ignored': 0, 'error': False}
         self.assertEqual(resp, expected)
 
     def test_save_documents_dupe_errors(self):
         """Test where we want to raise errors on duplicate documents."""
-        save_test_docs(3)
+        save_test_docs(_API_URL, 3)
         resp = requests.put(
-            API_URL + '/documents',
+            _API_URL + '/documents',
             params={'on_duplicate': 'error', 'collection': 'test_vertex', 'display_errors': '1'},
             data=create_test_docs(3),
-            headers=HEADERS_ADMIN
+            headers=_HEADERS_ADMIN
         ).json()
         self.assertEqual(resp['created'], 0)
         self.assertEqual(resp['errors'], 3)
@@ -236,22 +209,22 @@ class TestApi(unittest.TestCase):
     def test_save_documents_ignore_dupes(self):
         """Test ignoring duplicate, existing documents when saving."""
         resp = requests.put(
-            API_URL + '/documents',
+            _API_URL + '/documents',
             params={'on_duplicate': 'ignore', 'collection': 'test_vertex'},
             data=create_test_docs(3),
-            headers=HEADERS_ADMIN
+            headers=_HEADERS_ADMIN
         ).json()
         expected = {'created': 0, 'errors': 0, 'empty': 0, 'updated': 0, 'ignored': 3, 'error': False}
         self.assertEqual(resp, expected)
 
     def test_admin_query(self):
         """Test an ad-hoc query made by an admin."""
-        save_test_docs(1)
+        save_test_docs(_API_URL, 1)
         query = 'let ws_ids = @ws_ids for v in test_vertex sort rand() limit @count return v._id'
         resp = requests.post(
-            API_URL + '/query_results',
+            _API_URL + '/query_results',
             params={},
-            headers=HEADERS_ADMIN,
+            headers=_HEADERS_ADMIN,
             data=json.dumps({'query': query, 'count': 1})
         ).json()
         self.assertEqual(resp['count'], 1)
@@ -261,9 +234,9 @@ class TestApi(unittest.TestCase):
         """Test an ad-hoc query error as a non-admin."""
         query = 'let ws_ids = @ws_ids for v in test_vertex sort rand() limit @count return v._id'
         resp = requests.post(
-            API_URL + '/query_results',
+            _API_URL + '/query_results',
             params={},
-            headers=HEADERS_NON_ADMIN,
+            headers=_HEADERS_NON_ADMIN,
             data=json.dumps({'query': query, 'count': 1})
         ).json()
         self.assertEqual(resp['error'], '403 - Unauthorized')
@@ -272,18 +245,18 @@ class TestApi(unittest.TestCase):
         """Test the error response for an ad-hoc admin query without auth."""
         query = 'let ws_ids = @ws_ids for v in test_vertex sort rand() limit @count return v._id'
         resp = requests.post(
-            API_URL + '/query_results',
+            _API_URL + '/query_results',
             params={},
-            headers={'Authorization': INVALID_TOKEN},
+            headers={'Authorization': _INVALID_TOKEN},
             data=json.dumps({'query': query, 'count': 1})
         ).json()
         self.assertEqual(resp['error'], '403 - Unauthorized')
 
     def test_query_with_cursor(self):
         """Test getting more data via a query cursor and setting batch size."""
-        save_test_docs(count=20)
+        save_test_docs(_API_URL, count=20)
         resp = requests.post(
-            API_URL + '/query_results',
+            _API_URL + '/query_results',
             params={'view': 'list_test_vertices', 'batch_size': 10}
         ).json()
         self.assertTrue(resp['cursor_id'])
@@ -292,7 +265,7 @@ class TestApi(unittest.TestCase):
         self.assertTrue(len(resp['results']), 10)
         cursor_id = resp['cursor_id']
         resp = requests.post(
-            API_URL + '/query_results',
+            _API_URL + '/query_results',
             params={'cursor_id': cursor_id}
         ).json()
         self.assertEqual(resp['count'], 20)
@@ -301,7 +274,7 @@ class TestApi(unittest.TestCase):
         self.assertTrue(len(resp['results']), 10)
         # Try to get the same cursor again
         resp = requests.post(
-            API_URL + '/query_results',
+            _API_URL + '/query_results',
             params={'cursor_id': cursor_id}
         ).json()
         self.assertTrue(resp['error'])
@@ -310,7 +283,7 @@ class TestApi(unittest.TestCase):
     def test_query_no_name(self):
         """Test a query error with a view name that does not exist."""
         resp = requests.post(
-            API_URL + '/query_results',
+            _API_URL + '/query_results',
             params={'view': 'nonexistent'}
         ).json()
         self.assertEqual(resp['error'], 'View does not exist.')
@@ -319,7 +292,7 @@ class TestApi(unittest.TestCase):
     def test_query_missing_bind_var(self):
         """Test a query error with a missing bind variable."""
         resp = requests.post(
-            API_URL + '/query_results',
+            _API_URL + '/query_results',
             params={'view': 'list_test_vertices'},
             data=json.dumps({'xyz': 'test_vertex'})
         ).json()
@@ -331,17 +304,17 @@ class TestApi(unittest.TestCase):
         ws_id = 3
         # Remove all test vertices and create one with a ws_id
         requests.put(
-            API_URL + '/documents',
+            _API_URL + '/documents',
             params={'overwrite': True, 'collection': 'test_vertex'},
             data=json.dumps({
                 'name': 'requires_auth',
                 '_key': '123',
                 'ws_id': ws_id
             }),
-            headers=HEADERS_ADMIN
+            headers=_HEADERS_ADMIN
         )
         resp = requests.post(
-            API_URL + '/query_results',
+            _API_URL + '/query_results',
             params={'view': 'list_test_vertices'},
             headers={'Authorization': 'valid_token'}  # see ./mock_workspace/endpoints.json
         ).json()
@@ -352,13 +325,13 @@ class TestApi(unittest.TestCase):
         """Test the case where we try to query a collection without the right workspace access."""
         # Remove all test vertices and create one with a ws_id
         requests.put(
-            API_URL + '/documents',
+            _API_URL + '/documents',
             params={'overwrite': True, 'collection': 'test_vertex'},
             data='{"name": "requires_auth", "_key": "1", "ws_id": 9999}',
-            headers=HEADERS_ADMIN
+            headers=_HEADERS_ADMIN
         )
         resp = requests.post(
-            API_URL + '/query_results',
+            _API_URL + '/query_results',
             params={'view': 'list_test_vertices'},
             headers={'Authorization': 'valid_token'}  # see ./mock_workspace/endpoints.json
         ).json()
@@ -368,13 +341,13 @@ class TestApi(unittest.TestCase):
         """Test that users cannot set the ws_ids param."""
         ws_id = 99
         requests.put(
-            API_URL + '/documents',
+            _API_URL + '/documents',
             params={'overwrite': True, 'collection': 'test_vertex'},
             data='{"name": "requires_auth", "_key": "1", "ws_id": 99}',
-            headers=HEADERS_ADMIN
+            headers=_HEADERS_ADMIN
         )
         resp = requests.post(
-            API_URL + '/query_results',
+            _API_URL + '/query_results',
             params={'view': 'list_test_vertices'},
             data=json.dumps({'ws_ids': [ws_id]}),
             headers={'Authorization': 'valid_token'}
@@ -384,44 +357,45 @@ class TestApi(unittest.TestCase):
     def test_auth_query_invalid_token(self):
         """Test the case where we try to authorize a query using an invalid auth token."""
         requests.put(
-            API_URL + '/documents',
+            _API_URL + '/documents',
             params={'overwrite': True, 'collection': 'test_vertex'},
             data='{"name": "requires_auth", "_key": "1", "ws_id": 99}',
-            headers=HEADERS_ADMIN
+            headers=_HEADERS_ADMIN
         )
         resp = requests.post(
-            API_URL + '/query_results',
+            _API_URL + '/query_results',
             params={'view': 'list_test_vertices'},
             data=json.dumps({'ws_ids': [1]}),
-            headers={'Authorization': INVALID_TOKEN}
+            headers={'Authorization': _INVALID_TOKEN}
         )
         self.assertEqual(resp.status_code, 403)
 
     def test_auth_adhoc_query(self):
         """Test that the 'ws_ids' bind-var is set for RE_ADMINs."""
         ws_id = 99
-        requests.put(
-            API_URL + '/documents',
+        resp = requests.put(
+            _API_URL + '/documents',
             params={'overwrite': True, 'collection': 'test_vertex'},
-            data=json.dumps({'name': 'requires_auth', 'key': '1', 'ws_id': ws_id}),
-            headers={'Authorization': 'valid_token'}
+            data=json.dumps({'name': 'requires_auth', '_key': '1', 'ws_id': ws_id}),
+            headers={'Authorization': _ADMIN_TOKEN}
         )
+        self.assertTrue(resp.ok)
         # This is the same query as list_test_vertices.aql in the spec
         query = 'for o in test_vertex filter o.is_public || o.ws_id IN @ws_ids return o'
         resp = requests.post(
-            API_URL + '/query_results',
+            _API_URL + '/query_results',
             data=json.dumps({'query': query}),
-            headers={'Authorization': ADMIN_TOKEN}  # see ./mock_workspace/endpoints.json
+            headers={'Authorization': _ADMIN_TOKEN}  # see ./mock_workspace/endpoints.json
         ).json()
         self.assertEqual(resp['count'], 1)
 
     def test_queries_are_readonly(self):
         """Test that ad-hoc admin queries cannot do any writing."""
-        save_test_docs(1)
+        save_test_docs(_API_URL, 1)
         query = 'let ws_ids = @ws_ids for v in test_vertex remove v in test_vertex'
         resp = requests.post(
-            API_URL + '/query_results',
-            headers=HEADERS_ADMIN,
+            _API_URL + '/query_results',
+            headers=_HEADERS_ADMIN,
             data=json.dumps({'query': query})
         ).json()
         self.assertTrue(resp['error'])
@@ -430,13 +404,13 @@ class TestApi(unittest.TestCase):
     def test_no_version_in_path(self):
         """Test that leaving out api version in the path falls back to v1"""
         # TODO XXX temporary
-        save_test_docs(1)
+        save_test_docs(_API_URL, 1)
         query = 'let ws_ids = @ws_ids for v in test_vertex sort rand() limit @count return v._id'
-        url = '/'.join([URL, 'api'])  # Leaving off version
+        url = '/'.join([_URL, 'api'])  # Leaving off version
         resp = requests.post(
             url + '/query_results',
             params={},
-            headers=HEADERS_ADMIN,
+            headers=_HEADERS_ADMIN,
             data=json.dumps({'query': query, 'count': 1})
         ).json()
         self.assertEqual(resp['count'], 1)

--- a/src/test/test_api_v2.py
+++ b/src/test/test_api_v2.py
@@ -1,0 +1,175 @@
+"""
+Integration tests on API v2 methods.
+
+Version 2 adds Jinja2 templating support on stored queries.
+"""
+import unittest
+import requests
+import json
+import os
+
+from src.test.utils import save_test_docs
+
+# Use the mock auth tokens
+_ADMIN_TOKEN = 'admin_token'
+_INVALID_TOKEN = 'invalid_token'
+
+# Use the docker-compose url of the running flask server
+_URL = os.environ.get('TEST_URL', 'http://web:5000')
+_VERSION = 'v2'
+_API_URL = '/'.join([_URL, 'api', _VERSION])
+
+_HEADERS_ADMIN = {'Authorization': 'Bearer ' + _ADMIN_TOKEN, 'Content-Type': 'application/json'}
+
+
+class TestApi(unittest.TestCase):
+    """
+    Test all query functionality for API v2.
+    Make sure existing functionality still works, while jinja templating also works.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        # Initialize collections before running any tests
+        resp = requests.put(
+            _API_URL + '/specs',
+            headers=_HEADERS_ADMIN,
+            params={'init_collections': '1'}
+        )
+        print('update_specs response', resp.text)
+
+    def test_query_with_cursor(self):
+        """Test getting more data via a query cursor and setting batch size."""
+        save_test_docs(_API_URL, count=20)
+        resp = requests.post(
+            _API_URL + '/query_results',
+            params={'view': 'list_test_vertices', 'batch_size': 10}
+        ).json()
+        self.assertTrue(resp['cursor_id'])
+        self.assertEqual(resp['has_more'], True)
+        self.assertEqual(resp['count'], 20)
+        self.assertTrue(len(resp['results']), 10)
+        cursor_id = resp['cursor_id']
+        resp = requests.post(
+            _API_URL + '/query_results',
+            params={'cursor_id': cursor_id}
+        ).json()
+        self.assertEqual(resp['count'], 20)
+        self.assertEqual(resp['has_more'], False)
+        self.assertEqual(resp['cursor_id'], None)
+        self.assertTrue(len(resp['results']), 10)
+        # Try to get the same cursor again
+        resp = requests.post(
+            _API_URL + '/query_results',
+            params={'cursor_id': cursor_id}
+        ).json()
+        self.assertTrue(resp['error'])
+        self.assertEqual(resp['arango_message'], 'cursor not found')
+
+    def test_query_no_name(self):
+        """Test a query error with a view name that does not exist."""
+        resp = requests.post(
+            _API_URL + '/query_results',
+            params={'view': 'nonexistent'}
+        ).json()
+        self.assertEqual(resp['error'], 'View does not exist.')
+        self.assertEqual(resp['name'], 'nonexistent')
+
+    def test_query_missing_bind_var(self):
+        """Test a query error with a missing bind variable."""
+        resp = requests.post(
+            _API_URL + '/query_results',
+            params={'view': 'list_test_vertices'},
+            data=json.dumps({'bind_vars': {'xyz': 'test_vertex'}})
+        ).json()
+        self.assertEqual(resp['error'], 'ArangoDB server error.')
+        self.assertTrue(resp['arango_message'])
+
+    def test_auth_query_with_access(self):
+        """Test the case where we query a collection with specific workspace access."""
+        ws_id = 3
+        # Remove all test vertices and create one with a ws_id
+        requests.put(
+            _API_URL + '/documents',
+            params={'overwrite': True, 'collection': 'test_vertex'},
+            data=json.dumps({
+                'name': 'requires_auth',
+                '_key': '123',
+                'ws_id': ws_id
+            }),
+            headers=_HEADERS_ADMIN
+        )
+        resp = requests.post(
+            _API_URL + '/query_results',
+            params={'view': 'list_test_vertices'},
+            headers={'Authorization': 'valid_token'}  # see ./mock_workspace/endpoints.json
+        ).json()
+        self.assertEqual(resp['count'], 1)
+        self.assertEqual(resp['results'][0]['ws_id'], ws_id)
+
+    def test_auth_query_no_access(self):
+        """Test the case where we try to query a collection without the right workspace access."""
+        # Remove all test vertices and create one with a ws_id
+        requests.put(
+            _API_URL + '/documents',
+            params={'overwrite': True, 'collection': 'test_vertex'},
+            data='{"name": "requires_auth", "_key": "1", "ws_id": 9999}',
+            headers=_HEADERS_ADMIN
+        )
+        resp = requests.post(
+            _API_URL + '/query_results',
+            params={'view': 'list_test_vertices'},
+            headers={'Authorization': 'valid_token'}  # see ./mock_workspace/endpoints.json
+        ).json()
+        self.assertEqual(resp['count'], 0)
+
+    def test_query_cannot_pass_ws_ids(self):
+        """Test that users cannot set the ws_ids param."""
+        ws_id = 99
+        requests.put(
+            _API_URL + '/documents',
+            params={'overwrite': True, 'collection': 'test_vertex'},
+            data='{"name": "requires_auth", "_key": "1", "ws_id": 99}',
+            headers=_HEADERS_ADMIN
+        )
+        resp = requests.post(
+            _API_URL + '/query_results',
+            params={'view': 'list_test_vertices'},
+            data=json.dumps({'bind_vars': {'ws_ids': [ws_id]}}),
+            headers={'Authorization': 'valid_token'}
+        ).json()
+        self.assertEqual(resp['count'], 0)
+
+    def test_auth_query_invalid_token(self):
+        """Test the case where we try to authorize a query using an invalid auth token."""
+        requests.put(
+            _API_URL + '/documents',
+            params={'overwrite': True, 'collection': 'test_vertex'},
+            data='{"name": "requires_auth", "_key": "1", "ws_id": 99}',
+            headers=_HEADERS_ADMIN
+        )
+        resp = requests.post(
+            _API_URL + '/query_results',
+            params={'view': 'list_test_vertices'},
+            headers={'Authorization': _INVALID_TOKEN}
+        )
+        self.assertEqual(resp.status_code, 403)
+
+    def test_auth_adhoc_query(self):
+        """Test that the 'ws_ids' bind-var is set for RE_ADMINs."""
+        ws_id = 99
+        res = requests.put(
+            _API_URL + '/documents',
+            params={'overwrite': True, 'collection': 'test_vertex'},
+            data=json.dumps({'name': 'requires_auth', '_key': '1', 'ws_id': ws_id}),
+            headers={'Authorization': _ADMIN_TOKEN}
+        )
+        self.assertTrue(res.ok)
+        # This is the same query as list_test_vertices.aql in the spec
+        query = 'for o in test_vertex filter o.is_public || o.ws_id IN @ws_ids return o'
+        resp = requests.post(
+            _API_URL + '/query_results',
+            data=json.dumps({'query': query}),
+            headers={'Authorization': _ADMIN_TOKEN}  # see ./mock_workspace/endpoints.json
+        ).json()
+        self.assertEqual(resp['count'], 1)

--- a/src/test/utils.py
+++ b/src/test/utils.py
@@ -1,0 +1,31 @@
+import requests
+
+
+def create_test_docs(count):
+    """Produce some test documents."""
+    def doc(i):
+        return '{"name": "name", "_key": "%s", "is_public": true}' % i
+    return '\n'.join(doc(i) for i in range(0, count))
+
+
+def create_test_edges(count):
+    """Produce some test edges."""
+    def doc(i):
+        return '{"_from": "test_vertex/%s", "_to": "test_vertex/%s"}' % (i, i)
+    return '\n'.join(doc(i) for i in range(0, count))
+
+
+def save_test_docs(url, count, edges=False):
+    headers = {'Authorization': 'Bearer admin_token', 'Content-Type': 'application/json'}
+    if edges:
+        docs = create_test_edges(count)
+        collection = 'test_edge'
+    else:
+        docs = create_test_docs(count)
+        collection = 'test_vertex'
+    return requests.put(
+        url + '/documents',
+        params={'overwrite': True, 'collection': collection},
+        data=docs,
+        headers=headers
+    ).json()


### PR DESCRIPTION
This adds some initial basic support. I want to get a test jinja template stored query up in the spec repo and use that in the tests here. It's pretty awkward having to juggle changes between the api and spec like this. But maybe this is an unusual case and a non-issue 99% of the time.


- [ ] I updated the README.md docs to reflect this change.
- [ ] This is not a breaking API change OR 
- [x] This is a breaking API change and I have incremented the API version.
