### PR TITLE
Actually use the db name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,10 @@
-.PHONY: test
+.PHONY: test reset
 
 test:
 	docker-compose run web sh scripts/run_tests.sh
+
+reset:
+	docker-compose down
+	docker-compose rm -vf
+	docker-compose build --no-cache
+	docker-compose up

--- a/src/relation_engine_server/utils/arango_client.py
+++ b/src/relation_engine_server/utils/arango_client.py
@@ -26,7 +26,7 @@ def server_status():
 def run_query(query_text=None, cursor_id=None, bind_vars=None, batch_size=100, full_count=False):
     """Run a query using the arangodb http api. Can return a cursor to get more results."""
     config = get_config()
-    url = config['db_url'] + '/_api/cursor'
+    url = config['api_url'] + '/cursor'
     req_json = {
         'batchSize': min(5000, batch_size),
         'memoryLimit': 16000000000,  # 16gb
@@ -81,7 +81,7 @@ def create_collection(name, is_edge):
     """
     num_shards = os.environ.get('SHARD_COUNT', 30)
     config = get_config()
-    url = config['db_url'] + '/_api/collection'
+    url = config['api_url'] + '/collection'
     # collection types:
     #   2 is a document collection
     #   3 is an edge collection
@@ -105,7 +105,7 @@ def import_from_file(file_path, query):
     config = get_config()
     with open(file_path, 'rb') as file_desc:
         resp = requests.post(
-            config['db_url'] + '/_api/import',
+            config['api_url'] + '/import',
             data=file_desc,
             auth=(config['db_user'], config['db_pass']),
             params=query
@@ -126,20 +126,20 @@ def _init_readonly_user():
     user = config['db_readonly_user']
     # Check if the user exists, in which case this is a no-op
     resp = requests.get(
-        config['db_url'] + '/_api/user/' + user,
+        config['api_url'] + '/user/' + user,
         auth=(config['db_user'], config['db_pass'])
     )
     if resp.status_code == 200:
         return
     # Create the user
     resp = requests.post(
-        config['db_url'] + '/_api/user',
+        config['api_url'] + '/user',
         data=json.dumps({'user': user, 'passwd': config['db_readonly_user']}),
         auth=(config['db_user'], config['db_pass'])
     )
     if resp.status_code != 201:
         raise ArangoServerError(resp.text)
-    db_grant_path = config['db_url'] + '/_api/user/' + user + '/database/' + config['db_name']
+    db_grant_path = config['api_url'] + '/user/' + user + '/database/' + config['db_name']
     # Grant read access to the current database
     resp = requests.put(
         db_grant_path,

--- a/src/relation_engine_server/utils/config.py
+++ b/src/relation_engine_server/utils/config.py
@@ -18,6 +18,7 @@ def get_config():
     db_name = os.environ.get('DB_NAME', '_system')
     db_user = os.environ.get('DB_USER', 'root')
     db_pass = os.environ.get('DB_PASS', '')
+    api_url = db_url + '/_db/' + db_name + '/_api'
     db_readonly_user = os.environ.get('DB_READONLY_USER', 'readonly')
     db_readonly_pass = os.environ.get('DB_READONLY_PASS', 'readonly')
     return {
@@ -25,6 +26,7 @@ def get_config():
         'workspace_url': workspace_url,
         'kbase_endpoint': kbase_endpoint,
         'db_url': db_url,
+        'api_url': api_url,
         'db_name': db_name,
         'db_user': db_user,
         'db_pass': db_pass,


### PR DESCRIPTION
We weren't really making use of the DB_name in the api calls...

Also included that Makefile update in here as I don't think we'll merge the Jinja2 PR. 

- [x] I updated the README.md docs to reflect this change.
- [x] This is not a breaking API change OR 
- [ ] This is a breaking API change and I have incremented the API version.
