### PR TITLE
Add maxint query global

### DIFF
--- a/src/relation_engine_server/utils/arango_client.py
+++ b/src/relation_engine_server/utils/arango_client.py
@@ -14,8 +14,10 @@ _CONF = get_config()
 
 def server_status():
     """Get the status of our connection and authorization to the ArangoDB server."""
+    auth = (_CONF['db_user'], _CONF['db_pass'])
+    adb_url = f"{_CONF['api_url']}/version"
     try:
-        resp = requests.get(_CONF['db_url'] + '/_api/database/current', auth=(_CONF['db_user'], _CONF['db_pass']))
+        resp = requests.get(adb_url, auth=auth)
     except requests.exceptions.ConnectionError:
         return 'no_connection'
     if resp.ok:

--- a/src/relation_engine_server/wait_for_services.py
+++ b/src/relation_engine_server/wait_for_services.py
@@ -16,7 +16,7 @@ def main():
             requests.get(_CONFIG['workspace_url'])
             requests.get(_CONFIG['auth_url'])
             auth = (_CONFIG['db_user'], _CONFIG['db_pass'])
-            requests.get(_CONFIG['db_url'] + '/_admin/cluster/health', auth=auth).raise_for_status()
+            requests.get(_CONFIG['db_url'] + '/_api/database/current', auth=auth).raise_for_status()
             break
         except Exception:
             print('Waiting for services..')

--- a/src/relation_engine_server/wait_for_services.py
+++ b/src/relation_engine_server/wait_for_services.py
@@ -11,12 +11,13 @@ _CONFIG = get_config()
 
 def main():
     timeout = int(time.time()) + 60
+    adb_url = f"{_CONFIG['api_url']}/version"
     while True:
         try:
             requests.get(_CONFIG['workspace_url'])
             requests.get(_CONFIG['auth_url'])
             auth = (_CONFIG['db_user'], _CONFIG['db_pass'])
-            requests.get(_CONFIG['db_url'] + '/_api/database/current', auth=auth).raise_for_status()
+            requests.get(adb_url, auth=auth).raise_for_status()
             break
         except Exception:
             print('Waiting for services..')


### PR DESCRIPTION
Adds a globally defined variable called "maxint" to represent the un-expired nodes in time travel. Useful so we don't repeat this int all over our queries.

This also sneaks in a change that fixes some permissions issues when doing an arango health check.

- [ ] I updated the README.md docs to reflect this change.
- [x] This is not a breaking API change OR 
- [ ] This is a breaking API change and I have incremented the API version.
