### PR TITLE
Improve the json schema error response

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Returns server status info
 
 Run a query using a stored query or a cursor ID. Semantically, this is a GET, but it's a POST to allow better support for passing JSON in the request body (eg. Postman doesn't allow request body data in get requests)
 
-_Example rquest_
+_Example request_
 
 ```sh
 curl -X POST -d '{"argument": "value"}' {root_url}/api/v1/query_results?stored_query=example
@@ -159,6 +159,15 @@ _Response JSON schema_
   }
 }
 ```
+
+#### JSON Schema error responses
+
+If you try to update a collection and it fails validation against a JSON schema found in the [relation_engine_spec](https://github.com/kbase/relation_engine_spec/), then you will get a JSON error response with the following fields:
+
+* `"error"` - Human readable message explaining the error
+* `"failed_validator"` - The name of the validator that failed (eg. "required")
+* `"value"` - The (possibly nested) value in your data that failed validation
+* `"path"` - The path into your data where you can find the value that failed validation
 
 ### PUT /api/v1/specs/
 

--- a/src/relation_engine_server/main.py
+++ b/src/relation_engine_server/main.py
@@ -75,6 +75,8 @@ def view_does_not_exist(err):
 @app.errorhandler(ValidationError)
 def validation_error(err):
     """Json Schema validation error."""
+    # Refer to the documentation on jsonschema.exceptions.ValidationError:
+    # https://python-jsonschema.readthedocs.io/en/stable/errors/
     resp = {
         'error': err.message,
         'failed_validator': err.validator,

--- a/src/relation_engine_server/main.py
+++ b/src/relation_engine_server/main.py
@@ -76,11 +76,11 @@ def view_does_not_exist(err):
 def validation_error(err):
     """Json Schema validation error."""
     resp = {
-        'error': str(err).split('\n')[0],
-        'instance': err.instance,
-        'validator': err.validator,
+        'error': err.message,
+        'failed_validator': err.validator,
         'validator_value': err.validator_value,
-        'schema': err.schema
+        'path': list(err.absolute_path),
+        'schema_path': list(err.schema_path)
     }
     return (flask.jsonify(resp), 400)
 

--- a/src/test/test_api_v1.py
+++ b/src/test/test_api_v1.py
@@ -146,9 +146,9 @@ class TestApi(unittest.TestCase):
             headers=HEADERS_ADMIN
         ).json()
         self.assertEqual(resp['error'], "'_key' is a required property")
-        self.assertEqual(resp['instance'], {'name': 'x'})
-        self.assertTrue(resp['schema'])
-        self.assertEqual(resp['validator'], 'required')
+        self.assertEqual(resp['failed_validator'], 'required')
+        self.assertEqual(resp['path'], [])
+        self.assertEqual(resp['schema_path'], ['required'])
         self.assertEqual(resp['validator_value'], ['_key'])
 
     def test_save_documents_missing_schema(self):


### PR DESCRIPTION
Instead of the returning the whole schema, I would rather see just the path to the data that had the error along with the validation error message.